### PR TITLE
feat: Vulkan GPU acceleration for Android/Linux/Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,10 +212,19 @@ jobs:
           ndk-version: r26c
           add-to-path: true
 
-      - name: Install CMake, Ninja, and Vulkan tools
+      - name: Install CMake and Ninja
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build ccache shaderc
+          sudo apt-get install -y cmake ninja-build ccache
+
+      - name: Add NDK glslc to PATH (for Vulkan shader compilation)
+        run: |
+          GLSLC_DIR="${{ steps.setup-ndk.outputs.ndk-path }}/shader-tools/linux-x86_64"
+          if [ -f "$GLSLC_DIR/glslc" ]; then
+            echo "$GLSLC_DIR" >> $GITHUB_PATH
+          else
+            sudo apt-get install -y glslang-tools
+          fi
 
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,19 +212,24 @@ jobs:
           ndk-version: r26c
           add-to-path: true
 
-      - name: Install CMake and Ninja
+      - name: Install CMake, Ninja, and Vulkan SDK
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build ccache
+          sudo apt-get install -y cmake ninja-build ccache libvulkan-dev
 
-      - name: Add NDK glslc to PATH (for Vulkan shader compilation)
+      - name: Setup Vulkan for Android cross-compilation
         run: |
+          # Add NDK glslc to PATH for shader compilation
           GLSLC_DIR="${{ steps.setup-ndk.outputs.ndk-path }}/shader-tools/linux-x86_64"
           if [ -f "$GLSLC_DIR/glslc" ]; then
             echo "$GLSLC_DIR" >> $GITHUB_PATH
-          else
-            sudo apt-get install -y glslang-tools
           fi
+          # NDK has Vulkan C headers but not C++ headers (vulkan.hpp)
+          # Copy host C++ headers into NDK include path for cross-compilation
+          NDK_VK="${{ steps.setup-ndk.outputs.ndk-path }}/sources/third_party/vulkan/src/include/vulkan"
+          for f in /usr/include/vulkan/*.hpp; do
+            sudo cp "$f" "$NDK_VK/" 2>/dev/null || true
+          done
 
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,10 +212,10 @@ jobs:
           ndk-version: r26c
           add-to-path: true
 
-      - name: Install CMake and Ninja
+      - name: Install CMake, Ninja, and Vulkan tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build ccache
+          sudo apt-get install -y cmake ninja-build ccache shaderc
 
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,31 +212,10 @@ jobs:
           ndk-version: r26c
           add-to-path: true
 
-      - name: Install CMake, Ninja, and Vulkan SDK
+      - name: Install CMake and Ninja
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build ccache libvulkan-dev
-
-      - name: Setup Vulkan for Android cross-compilation
-        run: |
-          # Add NDK glslc to PATH for shader compilation
-          GLSLC_DIR="${{ steps.setup-ndk.outputs.ndk-path }}/shader-tools/linux-x86_64"
-          if [ -f "$GLSLC_DIR/glslc" ]; then
-            echo "$GLSLC_DIR" >> $GITHUB_PATH
-          fi
-          # NDK has Vulkan C headers (vulkan.h) but NOT C++ headers (vulkan.hpp)
-          # The compiler's --sysroot points to NDK's sysroot, so we must place
-          # vulkan.hpp there for #include <vulkan/vulkan.hpp> to resolve
-          NDK_SYSROOT_VK="${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/vulkan"
-          # Download Vulkan C++ headers from Khronos (compatible with NDK r26c)
-          VULKAN_HPP_TAG="v1.3.268"
-          TMP_VK_HPP=$(mktemp -d)
-          curl -sL "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/${VULKAN_HPP_TAG}.tar.gz" | \
-            tar xz -C "$TMP_VK_HPP"
-          sudo cp "$TMP_VK_HPP"/Vulkan-Headers-*/include/vulkan/*.hpp "$NDK_SYSROOT_VK/"
-          rm -rf "$TMP_VK_HPP"
-          echo "Vulkan C++ headers installed in NDK sysroot:"
-          ls "$NDK_SYSROOT_VK"/*.hpp | head -5
+          sudo apt-get install -y cmake ninja-build ccache
 
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -252,11 +231,11 @@ jobs:
         run: |
           echo "Android shared library sizes:"
           find build/android/jniLibs -name "*.so" -exec ls -lh {} \;
-          # Fail if any .so exceeds 35MB (3 engines: llama + whisper + SD)
+          # Fail if any .so exceeds 60MB (3 engines: llama + whisper + SD + Vulkan GPU backend)
           find build/android/jniLibs -name "libedge_veda.so" | while read file; do
             size=$(stat -c%s "$file")
-            if [ $size -gt 36700160 ]; then
-              echo "ERROR: $file is too large: $size bytes (>35MB)"
+            if [ $size -gt 62914560 ]; then
+              echo "ERROR: $file is too large: $size bytes (>60MB)"
               exit 1
             fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,19 @@ jobs:
           if [ -f "$GLSLC_DIR/glslc" ]; then
             echo "$GLSLC_DIR" >> $GITHUB_PATH
           fi
-          # NDK has Vulkan C headers but not C++ headers (vulkan.hpp)
-          # Copy host C++ headers into NDK include path for cross-compilation
-          NDK_VK="${{ steps.setup-ndk.outputs.ndk-path }}/sources/third_party/vulkan/src/include/vulkan"
-          for f in /usr/include/vulkan/*.hpp; do
-            sudo cp "$f" "$NDK_VK/" 2>/dev/null || true
-          done
+          # NDK has Vulkan C headers (vulkan.h) but NOT C++ headers (vulkan.hpp)
+          # The compiler's --sysroot points to NDK's sysroot, so we must place
+          # vulkan.hpp there for #include <vulkan/vulkan.hpp> to resolve
+          NDK_SYSROOT_VK="${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/vulkan"
+          # Download Vulkan C++ headers from Khronos (compatible with NDK r26c)
+          VULKAN_HPP_TAG="v1.3.268"
+          TMP_VK_HPP=$(mktemp -d)
+          curl -sL "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/${VULKAN_HPP_TAG}.tar.gz" | \
+            tar xz -C "$TMP_VK_HPP"
+          sudo cp "$TMP_VK_HPP"/Vulkan-Headers-*/include/vulkan/*.hpp "$NDK_SYSROOT_VK/"
+          rm -rf "$TMP_VK_HPP"
+          echo "Vulkan C++ headers installed in NDK sysroot:"
+          ls "$NDK_SYSROOT_VK"/*.hpp | head -5
 
       - name: Configure ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -82,6 +82,7 @@ set(EDGE_VEDA_SOURCES
     src/vision_engine.cpp
     src/whisper_engine.cpp
     src/image_engine.cpp
+    src/vulkan_denylist.cpp
 )
 
 # Header files

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
 endif()
 
 option(EDGE_VEDA_ENABLE_METAL "Enable Metal backend for iOS/macOS" ${METAL_DEFAULT})
-option(EDGE_VEDA_ENABLE_VULKAN "Enable Vulkan backend for Android" OFF)  # Phase 5: CPU-only, Vulkan deferred to Phase 7
+option(EDGE_VEDA_ENABLE_VULKAN "Enable Vulkan backend for Android/Linux/Windows" OFF)
 option(EDGE_VEDA_ENABLE_CPU "Enable CPU backend (always available)" ON)
 option(EDGE_VEDA_BUILD_SHARED "Build shared library" ON)
 option(EDGE_VEDA_BUILD_STATIC "Build static library" OFF)
@@ -104,8 +104,10 @@ endif()
 
 # Android-specific llama.cpp configuration (BEFORE add_subdirectory)
 if(ANDROID)
-    # CRITICAL: CPU-only build for Phase 5 (Vulkan deferred to Phase 7)
-    set(GGML_VULKAN OFF CACHE BOOL "" FORCE)
+    # Vulkan backend controlled by EDGE_VEDA_ENABLE_VULKAN (default OFF)
+    if(NOT EDGE_VEDA_ENABLE_VULKAN)
+        set(GGML_VULKAN OFF CACHE BOOL "" FORCE)
+    endif()
 
     # CRITICAL: Disable OpenMP - causes dlopen failures on many Android devices
     # that don't ship libgomp. CPU backend works fine without it.
@@ -152,7 +154,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/llama.cpp/CMakeLists.txt")
         set(GGML_ACCELERATE ON CACHE BOOL "" FORCE)
     endif()
 
-    # Enable Vulkan for llama.cpp on Android
+    # Enable Vulkan for llama.cpp on Android/Linux/Windows
     if(EDGE_VEDA_ENABLE_VULKAN)
         set(GGML_VULKAN ON CACHE BOOL "" FORCE)
     endif()

--- a/core/cmake/android.toolchain.cmake
+++ b/core/cmake/android.toolchain.cmake
@@ -98,8 +98,11 @@ elseif(ANDROID_ABI STREQUAL "x86_64")
 endif()
 
 # Vulkan support detection
+# NDK r26 and earlier: sources/third_party/vulkan/src/include
+# NDK r27+: headers are in the sysroot (toolchains/llvm/prebuilt/*/sysroot/usr/include)
 find_path(VULKAN_INCLUDE_DIR vulkan/vulkan.h
     PATHS ${ANDROID_NDK}/sources/third_party/vulkan/src/include
+          ${CMAKE_SYSROOT}/usr/include
     NO_DEFAULT_PATH
 )
 

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -24,6 +24,11 @@
 #include "ggml.h"
 #endif
 
+#ifdef EDGE_VEDA_VULKAN_ENABLED
+#include "ggml-vulkan.h"
+#include "vulkan_denylist.h"
+#endif
+
 #include "memory_guard.h"
 #include "thread_utils.h"
 
@@ -237,10 +242,20 @@ ev_backend_t ev_detect_backend(void) {
             return EV_BACKEND_METAL;
         #endif
     #endif
-#elif defined(__ANDROID__)
-    #ifdef EDGE_VEDA_VULKAN_ENABLED
-        return EV_BACKEND_VULKAN;
-    #endif
+#elif defined(EDGE_VEDA_VULKAN_ENABLED)
+    // Runtime Vulkan detection: check if a working device actually exists
+    {
+        int vk_count = ggml_backend_vk_get_device_count();
+        if (vk_count > 0) {
+            char desc[256] = {0};
+            ggml_backend_vk_get_device_description(0, desc, sizeof(desc));
+            if (!ev_vulkan_is_denied(desc)) {
+                return EV_BACKEND_VULKAN;
+            }
+            // Denied driver — fall through to CPU
+        }
+        // No Vulkan device or denied — fall through to CPU
+    }
 #endif
 
 #ifdef EDGE_VEDA_CPU_ENABLED
@@ -261,7 +276,15 @@ bool ev_is_backend_available(ev_backend_t backend) {
 
         case EV_BACKEND_VULKAN:
 #ifdef EDGE_VEDA_VULKAN_ENABLED
-            return true;
+            {
+                int vk_count = ggml_backend_vk_get_device_count();
+                if (vk_count > 0) {
+                    char desc[256] = {0};
+                    ggml_backend_vk_get_device_description(0, desc, sizeof(desc));
+                    return !ev_vulkan_is_denied(desc);
+                }
+                return false;
+            }
 #else
             return false;
 #endif
@@ -359,6 +382,39 @@ ev_context ev_init(const ev_config* config, ev_error_t* error) {
     model_params.n_gpu_layers = config->gpu_layers;
     model_params.use_mmap = config->use_mmap;
     model_params.use_mlock = config->use_mlock;
+
+#ifdef EDGE_VEDA_VULKAN_ENABLED
+    // VRAM-based GPU layer heuristic for Vulkan on integrated GPUs.
+    // When gpu_layers == -1 (auto) and Vulkan is active, compute a safe
+    // layer count from available VRAM instead of offloading everything
+    // (which would OOM on mobile devices with shared memory).
+    if (ctx->active_backend == EV_BACKEND_VULKAN && config->gpu_layers == -1) {
+        size_t vram_free = 0, vram_total = 0;
+        ggml_backend_vk_get_device_memory(0, &vram_free, &vram_total);
+
+        // On integrated GPUs (all mobile), VRAM reports shared system RAM.
+        // Use a conservative 40% of reported free memory as GPU budget.
+        size_t vram_budget = static_cast<size_t>(vram_free * 0.40);
+
+        // Conservative default: 16 layers is safe for small models on
+        // most mobile GPUs. This will be refined once we can inspect
+        // actual model layer count and per-layer size after loading.
+        // For now, cap at a safe starting point based on VRAM budget.
+        int estimated_layers = 16; // safe baseline for 1-3B models
+        if (vram_budget > 2ULL * 1024 * 1024 * 1024) {
+            // > 2GB budget: offload generously (large models or desktop GPU)
+            estimated_layers = 99; // llama.cpp clamps to actual layer count
+        } else if (vram_budget > 1ULL * 1024 * 1024 * 1024) {
+            // 1-2GB budget: moderate offload
+            estimated_layers = 32;
+        } else if (vram_budget < 256ULL * 1024 * 1024) {
+            // < 256MB: very constrained, minimal offload
+            estimated_layers = 4;
+        }
+
+        model_params.n_gpu_layers = estimated_layers;
+    }
+#endif
 
     // Load model (using new API: llama_model_load_from_file)
     ctx->model = llama_model_load_from_file(ctx->model_path.c_str(), model_params);

--- a/core/src/vulkan_denylist.cpp
+++ b/core/src/vulkan_denylist.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file vulkan_denylist.cpp
+ * @brief Vulkan driver denylist implementation
+ *
+ * Maintains a static table of known-broken Vulkan drivers identified
+ * by substring matching against the device description string returned
+ * by ggml_backend_vk_get_device_description().
+ *
+ * Sources:
+ * - Adreno 5xx: llama.cpp #16881 (gibberish output from compute shaders)
+ * - PowerVR: insufficient Vulkan compute shader support for ggml workloads
+ */
+
+#include "vulkan_denylist.h"
+#include <cstring>
+
+struct DenylistEntry {
+    const char* substring;  // Matched against device description
+    const char* reason;     // Human-readable reason for logging
+};
+
+// Populated from community reports and llama.cpp issue tracker.
+// Add entries as broken drivers are discovered during testing.
+static const DenylistEntry VULKAN_DENYLIST[] = {
+    // Adreno 5xx series: known gibberish output (llama.cpp #16881)
+    {"Adreno (TM) 5", "Adreno 500 series: incorrect compute results"},
+
+    // PowerVR: very limited Vulkan compute shader support
+    {"PowerVR", "PowerVR: insufficient Vulkan compute support"},
+
+    // Sentinel
+    {nullptr, nullptr}
+};
+
+bool ev_vulkan_is_denied(const char* device_description) {
+    if (!device_description) return false;
+
+    for (int i = 0; VULKAN_DENYLIST[i].substring != nullptr; i++) {
+        if (strstr(device_description, VULKAN_DENYLIST[i].substring)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const char* ev_vulkan_deny_reason(const char* device_description) {
+    if (!device_description) return nullptr;
+
+    for (int i = 0; VULKAN_DENYLIST[i].substring != nullptr; i++) {
+        if (strstr(device_description, VULKAN_DENYLIST[i].substring)) {
+            return VULKAN_DENYLIST[i].reason;
+        }
+    }
+    return nullptr;
+}

--- a/core/src/vulkan_denylist.h
+++ b/core/src/vulkan_denylist.h
@@ -1,0 +1,35 @@
+/**
+ * @file vulkan_denylist.h
+ * @brief Vulkan driver denylist for known-broken GPU drivers
+ *
+ * Blocks GPU drivers with documented compute shader bugs or
+ * insufficient Vulkan support. Checked during runtime backend
+ * detection so that denied devices fall back to CPU silently.
+ */
+
+#ifndef EDGE_VEDA_VULKAN_DENYLIST_H
+#define EDGE_VEDA_VULKAN_DENYLIST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Check if a Vulkan device is on the denylist
+ * @param device_description Device description string from ggml_backend_vk_get_device_description
+ * @return true if the device is denied (should not be used), false if allowed
+ */
+bool ev_vulkan_is_denied(const char* device_description);
+
+/**
+ * @brief Get the denial reason for a Vulkan device
+ * @param device_description Device description string
+ * @return Reason string if denied, nullptr if device is allowed
+ */
+const char* ev_vulkan_deny_reason(const char* device_description);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EDGE_VEDA_VULKAN_DENYLIST_H */

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -60,7 +60,7 @@ android {
                 cppFlags "-std=c++17 -frtti -fexceptions"
                 arguments "-DANDROID_STL=c++_shared",
                           "-DANDROID_PLATFORM=android-24",
-                          "-DEDGE_VEDA_ENABLE_VULKAN=OFF",
+                          "-DEDGE_VEDA_ENABLE_VULKAN=ON",
                           "-DEDGE_VEDA_ENABLE_CPU=ON",
                           "-DGGML_OPENMP=OFF"
             }
@@ -108,7 +108,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'androidx.core:core:1.12.0'
-    // Vulkan support deferred to Phase 7
+    // Vulkan GPU acceleration enabled
 }
 
 // Copy native libraries to jniLibs

--- a/flutter/lib/src/edge_veda_impl.dart
+++ b/flutter/lib/src/edge_veda_impl.dart
@@ -175,7 +175,9 @@ class EdgeVeda {
           // Populate config
           configPtr.ref.modelPath = modelPathPtr;
           configPtr.ref.backend =
-              (useGpu && useVulkan) ? EvBackend.auto_.value : EvBackend.cpu.value;
+              (useGpu && useVulkan)
+                  ? EvBackend.auto_.value
+                  : EvBackend.cpu.value;
           configPtr.ref.numThreads = numThreads;
           configPtr.ref.contextSize = contextSize;
           configPtr.ref.batchSize = 512;

--- a/flutter/lib/src/edge_veda_impl.dart
+++ b/flutter/lib/src/edge_veda_impl.dart
@@ -155,6 +155,7 @@ class EdgeVeda {
     final numThreads = config.numThreads;
     final contextSize = config.contextLength;
     final useGpu = config.useGpu;
+    final useVulkan = config.useVulkan;
     final flashAttn = config.flashAttn;
     final kvCacheTypeK = config.kvCacheTypeK;
     final kvCacheTypeV = config.kvCacheTypeV;
@@ -174,13 +175,13 @@ class EdgeVeda {
           // Populate config
           configPtr.ref.modelPath = modelPathPtr;
           configPtr.ref.backend =
-              useGpu ? EvBackend.auto_.value : EvBackend.cpu.value;
+              (useGpu && useVulkan) ? EvBackend.auto_.value : EvBackend.cpu.value;
           configPtr.ref.numThreads = numThreads;
           configPtr.ref.contextSize = contextSize;
           configPtr.ref.batchSize = 512;
           configPtr.ref.memoryLimitBytes = 0;
           configPtr.ref.autoUnloadOnMemoryPressure = true;
-          configPtr.ref.gpuLayers = useGpu ? -1 : 0;
+          configPtr.ref.gpuLayers = (useGpu && useVulkan) ? -1 : 0;
           configPtr.ref.useMmap = true;
           configPtr.ref.useMlock = false;
           configPtr.ref.seed = -1;
@@ -420,6 +421,7 @@ class EdgeVeda {
           numThreads: _config!.numThreads,
           contextSize: _config!.contextLength,
           useGpu: _config!.useGpu,
+          useVulkan: _config!.useVulkan,
           memoryLimitBytes: _config!.maxMemoryMb * 1024 * 1024,
           flashAttn: _config!.flashAttn,
           kvCacheTypeK: _config!.kvCacheTypeK,
@@ -526,6 +528,7 @@ class EdgeVeda {
     final numThreads = _config!.numThreads;
     final contextSize = _config!.contextLength;
     final useGpu = _config!.useGpu;
+    final useVulkan = _config!.useVulkan;
     final flashAttn = _config!.flashAttn;
     final kvCacheTypeK = _config!.kvCacheTypeK;
     final kvCacheTypeV = _config!.kvCacheTypeV;
@@ -541,13 +544,13 @@ class EdgeVeda {
       try {
         configPtr.ref.modelPath = modelPathPtr;
         configPtr.ref.backend =
-            useGpu ? EvBackend.auto_.value : EvBackend.cpu.value;
+            (useGpu && useVulkan) ? EvBackend.auto_.value : EvBackend.cpu.value;
         configPtr.ref.numThreads = numThreads;
         configPtr.ref.contextSize = contextSize;
         configPtr.ref.batchSize = 512;
         configPtr.ref.memoryLimitBytes = 0;
         configPtr.ref.autoUnloadOnMemoryPressure = true;
-        configPtr.ref.gpuLayers = useGpu ? -1 : 0;
+        configPtr.ref.gpuLayers = (useGpu && useVulkan) ? -1 : 0;
         configPtr.ref.useMmap = true;
         configPtr.ref.useMlock = false;
         configPtr.ref.seed = -1;
@@ -628,6 +631,7 @@ class EdgeVeda {
     final numThreads = _config!.numThreads;
     final contextSize = _config!.contextLength;
     final useGpu = _config!.useGpu;
+    final useVulkan = _config!.useVulkan;
     final flashAttn = _config!.flashAttn;
     final kvCacheTypeK = _config!.kvCacheTypeK;
     final kvCacheTypeV = _config!.kvCacheTypeV;
@@ -643,13 +647,13 @@ class EdgeVeda {
       try {
         configPtr.ref.modelPath = modelPathPtr;
         configPtr.ref.backend =
-            useGpu ? EvBackend.auto_.value : EvBackend.cpu.value;
+            (useGpu && useVulkan) ? EvBackend.auto_.value : EvBackend.cpu.value;
         configPtr.ref.numThreads = numThreads;
         configPtr.ref.contextSize = contextSize;
         configPtr.ref.batchSize = 512;
         configPtr.ref.memoryLimitBytes = 0;
         configPtr.ref.autoUnloadOnMemoryPressure = true;
-        configPtr.ref.gpuLayers = useGpu ? -1 : 0;
+        configPtr.ref.gpuLayers = (useGpu && useVulkan) ? -1 : 0;
         configPtr.ref.useMmap = true;
         configPtr.ref.useMlock = false;
         configPtr.ref.seed = -1;

--- a/flutter/lib/src/ffi/bindings.dart
+++ b/flutter/lib/src/ffi/bindings.dart
@@ -79,6 +79,9 @@ enum EvBackend {
   /// Metal (iOS/macOS)
   metal(1),
 
+  /// Vulkan (Android/Linux/Windows)
+  vulkan(2),
+
   /// CPU fallback
   cpu(3);
 

--- a/flutter/lib/src/isolate/worker_isolate.dart
+++ b/flutter/lib/src/isolate/worker_isolate.dart
@@ -99,6 +99,7 @@ class StreamingWorker {
     required int numThreads,
     required int contextSize,
     required bool useGpu,
+    bool useVulkan = true,
     int memoryLimitBytes = 0,
     int flashAttn = -1,
     int kvCacheTypeK = 8,
@@ -122,6 +123,7 @@ class StreamingWorker {
         numThreads: numThreads,
         contextSize: contextSize,
         useGpu: useGpu,
+        useVulkan: useVulkan,
         memoryLimitBytes: memoryLimitBytes,
         flashAttn: flashAttn,
         kvCacheTypeK: kvCacheTypeK,
@@ -418,13 +420,13 @@ void _handleInit(
   try {
     configPtr.ref.modelPath = modelPathPtr;
     configPtr.ref.backend =
-        cmd.useGpu ? EvBackend.auto_.value : EvBackend.cpu.value;
+        (cmd.useGpu && cmd.useVulkan) ? EvBackend.auto_.value : EvBackend.cpu.value;
     configPtr.ref.numThreads = cmd.numThreads;
     configPtr.ref.contextSize = cmd.contextSize;
     configPtr.ref.batchSize = 512;
     configPtr.ref.memoryLimitBytes = cmd.memoryLimitBytes;
     configPtr.ref.autoUnloadOnMemoryPressure = true;
-    configPtr.ref.gpuLayers = cmd.useGpu ? -1 : 0;
+    configPtr.ref.gpuLayers = (cmd.useGpu && cmd.useVulkan) ? -1 : 0;
     configPtr.ref.useMmap = true;
     configPtr.ref.useMlock = false;
     configPtr.ref.seed = -1;

--- a/flutter/lib/src/isolate/worker_isolate.dart
+++ b/flutter/lib/src/isolate/worker_isolate.dart
@@ -420,7 +420,9 @@ void _handleInit(
   try {
     configPtr.ref.modelPath = modelPathPtr;
     configPtr.ref.backend =
-        (cmd.useGpu && cmd.useVulkan) ? EvBackend.auto_.value : EvBackend.cpu.value;
+        (cmd.useGpu && cmd.useVulkan)
+            ? EvBackend.auto_.value
+            : EvBackend.cpu.value;
     configPtr.ref.numThreads = cmd.numThreads;
     configPtr.ref.contextSize = cmd.contextSize;
     configPtr.ref.batchSize = 512;

--- a/flutter/lib/src/isolate/worker_messages.dart
+++ b/flutter/lib/src/isolate/worker_messages.dart
@@ -26,6 +26,9 @@ class InitWorkerCommand extends WorkerCommand {
   /// Use GPU acceleration (Metal on iOS)
   final bool useGpu;
 
+  /// Use Vulkan GPU acceleration (Android/Linux/Windows)
+  final bool useVulkan;
+
   /// Memory limit in bytes (0 = no limit)
   final int memoryLimitBytes;
 
@@ -43,6 +46,7 @@ class InitWorkerCommand extends WorkerCommand {
     required this.numThreads,
     required this.contextSize,
     required this.useGpu,
+    this.useVulkan = true,
     this.memoryLimitBytes = 0,
     this.flashAttn = -1,
     this.kvCacheTypeK = 8,

--- a/flutter/lib/src/types.dart
+++ b/flutter/lib/src/types.dart
@@ -41,6 +41,14 @@ class EdgeVedaConfig {
   /// Default is Q8_0 (8) for mobile memory optimization.
   final int kvCacheTypeV;
 
+  /// Enable Vulkan GPU acceleration on Android/Linux/Windows.
+  ///
+  /// When true (default) and Vulkan is available, inference runs on GPU
+  /// with automatic VRAM-based layer offload. When false or Vulkan is
+  /// unavailable, falls back to CPU transparently.
+  /// Has no effect on iOS/macOS (Metal is used instead via [useGpu]).
+  final bool useVulkan;
+
   const EdgeVedaConfig({
     required this.modelPath,
     this.numThreads = 4,
@@ -51,6 +59,7 @@ class EdgeVedaConfig {
     this.flashAttn = -1,
     this.kvCacheTypeK = 8,
     this.kvCacheTypeV = 8,
+    this.useVulkan = true,
   });
 
   Map<String, dynamic> toJson() => {
@@ -63,6 +72,7 @@ class EdgeVedaConfig {
     'flashAttn': flashAttn,
     'kvCacheTypeK': kvCacheTypeK,
     'kvCacheTypeV': kvCacheTypeV,
+    'useVulkan': useVulkan,
   };
 
   @override

--- a/flutter/test/android_build_script_test.dart
+++ b/flutter/test/android_build_script_test.dart
@@ -296,10 +296,11 @@ void main() {
       expect(content, contains('EDGE_VEDA_BUILD_STATIC=OFF'));
     });
 
-    test('disables Vulkan (CPU-only for initial build)', () {
+    test('supports Vulkan with --no-vulkan opt-out', () {
       if (!scriptFile.existsSync()) return;
       final content = scriptFile.readAsStringSync();
-      expect(content, contains('EDGE_VEDA_ENABLE_VULKAN=OFF'));
+      expect(content, contains('EDGE_VEDA_ENABLE_VULKAN='));
+      expect(content, contains('--no-vulkan'));
     });
 
     test('disables OpenMP (not available in NDK r26)', () {
@@ -502,8 +503,9 @@ void main() {
       final androidContent = scriptFile.readAsStringSync();
       final iosContent = iosScriptFile.readAsStringSync();
 
-      // Android has no Metal — uses ENABLE_VULKAN instead
-      expect(androidContent, contains('ENABLE_VULKAN=OFF'));
+      // Android has no Metal — uses Vulkan instead
+      expect(androidContent, contains('ENABLE_VULKAN='));
+      expect(androidContent, isNot(contains('ENABLE_METAL=')));
       expect(iosContent, contains('ENABLE_METAL=ON'));
     });
   });

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -122,6 +122,80 @@ check_tools() {
 check_tools
 
 # ============================================================================
+# Setup Vulkan C++ headers for cross-compilation
+# ============================================================================
+setup_vulkan() {
+    if [ "$VULKAN_ENABLED" != "ON" ]; then
+        return
+    fi
+
+    # Detect host OS for NDK prebuilt path
+    case "$(uname -s)" in
+        Linux*)  NDK_HOST="linux-x86_64" ;;
+        Darwin*) NDK_HOST="darwin-x86_64" ;;
+        *)       echo "WARNING: Unsupported host OS for Vulkan, disabling"; VULKAN_ENABLED="OFF"; return ;;
+    esac
+
+    NDK_SYSROOT_VK="$ANDROID_NDK/toolchains/llvm/prebuilt/$NDK_HOST/sysroot/usr/include/vulkan"
+
+    if [ ! -f "$NDK_SYSROOT_VK/vulkan_core.h" ]; then
+        echo "WARNING: Vulkan C headers not found in NDK sysroot, disabling Vulkan"
+        VULKAN_ENABLED="OFF"
+        return
+    fi
+
+    # Add glslc to PATH (must happen before any early returns)
+    GLSLC_DIR="$ANDROID_NDK/shader-tools/$NDK_HOST"
+    if [ -x "$GLSLC_DIR/glslc" ]; then
+        export PATH="$GLSLC_DIR:$PATH"
+        echo "Added NDK glslc to PATH: $GLSLC_DIR/glslc"
+    elif ! command -v glslc &>/dev/null; then
+        echo "WARNING: glslc not found, disabling Vulkan"
+        VULKAN_ENABLED="OFF"
+        return
+    fi
+
+    # Check if vulkan.hpp already exists (matching version)
+    if [ -f "$NDK_SYSROOT_VK/vulkan.hpp" ]; then
+        echo "Vulkan C++ headers already present in NDK sysroot"
+        return
+    fi
+
+    # Read VK_HEADER_VERSION from NDK's vulkan_core.h to download matching C++ headers
+    VK_VERSION=$(grep '#define VK_HEADER_VERSION ' "$NDK_SYSROOT_VK/vulkan_core.h" | awk '{print $3}')
+    if [ -z "$VK_VERSION" ]; then
+        echo "WARNING: Could not detect VK_HEADER_VERSION, disabling Vulkan"
+        VULKAN_ENABLED="OFF"
+        return
+    fi
+
+    VULKAN_HPP_VERSION="1.3.${VK_VERSION}"
+    VULKAN_HPP_TAG="v${VULKAN_HPP_VERSION}"
+    echo "NDK Vulkan header version: $VK_VERSION → downloading Vulkan-Headers $VULKAN_HPP_TAG"
+
+    TMP_VK_HPP=$(mktemp -d)
+    if curl -sL "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/${VULKAN_HPP_TAG}.tar.gz" | \
+        tar xz -C "$TMP_VK_HPP" 2>/dev/null; then
+        # Copy C++ headers (.hpp) into NDK sysroot alongside existing C headers
+        HPP_DIR="$TMP_VK_HPP/Vulkan-Headers-${VULKAN_HPP_VERSION}/include/vulkan"
+        if [ -d "$HPP_DIR" ]; then
+            cp "$HPP_DIR"/*.hpp "$NDK_SYSROOT_VK/" 2>/dev/null || \
+                sudo cp "$HPP_DIR"/*.hpp "$NDK_SYSROOT_VK/"
+            echo "Installed Vulkan C++ headers ($(ls "$NDK_SYSROOT_VK"/*.hpp 2>/dev/null | wc -l | tr -d ' ') files)"
+        else
+            echo "WARNING: Expected headers not found in downloaded archive, disabling Vulkan"
+            VULKAN_ENABLED="OFF"
+        fi
+    else
+        echo "WARNING: Failed to download Vulkan-Headers $VULKAN_HPP_TAG, disabling Vulkan"
+        VULKAN_ENABLED="OFF"
+    fi
+    rm -rf "$TMP_VK_HPP"
+}
+
+setup_vulkan
+
+# ============================================================================
 # Clean if requested
 # ============================================================================
 if [ "$CLEAN" = true ]; then
@@ -152,12 +226,25 @@ for abi in $ABIS; do
     BUILD_ABI_DIR="$BUILD_DIR/$abi"
     mkdir -p "$BUILD_ABI_DIR"
 
+    VULKAN_CMAKE_ARGS=""
+    ANDROID_API_LEVEL="android-24"
+    if [ "$VULKAN_ENABLED" = "ON" ]; then
+        # Vulkan 1.1 functions (vkGetPhysicalDeviceFeatures2 etc.) require API 29+
+        ANDROID_API_LEVEL="android-30"
+        # glslc is a host tool — must be passed explicitly during cross-compilation
+        # because cmake's find_program won't search host paths
+        GLSLC_EXE=$(command -v glslc 2>/dev/null || echo "")
+        if [ -n "$GLSLC_EXE" ]; then
+            VULKAN_CMAKE_ARGS="-DVulkan_GLSLC_EXECUTABLE=$GLSLC_EXE"
+        fi
+    fi
+
     cmake -B "$BUILD_ABI_DIR" \
         -S "$CORE_DIR" \
         -G Ninja \
         -DCMAKE_TOOLCHAIN_FILE="$CORE_DIR/cmake/android.toolchain.cmake" \
         -DANDROID_ABI="$abi" \
-        -DANDROID_PLATFORM=android-24 \
+        -DANDROID_PLATFORM=$ANDROID_API_LEVEL \
         -DANDROID_STL=c++_shared \
         -DANDROID_NDK="$ANDROID_NDK" \
         -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
@@ -165,7 +252,8 @@ for abi in $ABIS; do
         -DEDGE_VEDA_BUILD_STATIC=OFF \
         -DEDGE_VEDA_ENABLE_VULKAN=$VULKAN_ENABLED \
         -DEDGE_VEDA_ENABLE_CPU=ON \
-        -DGGML_OPENMP=OFF
+        -DGGML_OPENMP=OFF \
+        $VULKAN_CMAKE_ARGS
 
     cmake --build "$BUILD_ABI_DIR" --config "$BUILD_TYPE"
 
@@ -244,11 +332,11 @@ for abi in "${BUILT_ABIS[@]}"; do
     echo ""
     echo "--- $abi ---"
 
-    # File size check (warn if > 35MB per ABI — 3 engines: llama + whisper + SD)
+    # File size check (warn if > 60MB per ABI — 3 engines: llama + whisper + SD + Vulkan)
     SO_SIZE_KB=$(du -k "$SO_FILE" | cut -f1)
-    MAX_SIZE_KB=35840  # 35MB
+    MAX_SIZE_KB=61440  # 60MB
     if [ "$SO_SIZE_KB" -gt "$MAX_SIZE_KB" ]; then
-        echo "  WARNING: libedge_veda.so (${SO_SIZE_KB}KB) exceeds 35MB"
+        echo "  WARNING: libedge_veda.so (${SO_SIZE_KB}KB) exceeds 60MB"
     fi
     echo "  Size: ${SO_SIZE_KB}KB (warning threshold: ${MAX_SIZE_KB}KB)"
 

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -20,6 +20,7 @@ OUTPUT_DIR="$BUILD_DIR/jniLibs"
 CLEAN=false
 BUILD_TYPE="Release"
 ABIS="arm64-v8a armeabi-v7a x86_64"
+VULKAN_ENABLED="ON"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -35,6 +36,10 @@ while [[ $# -gt 0 ]]; do
             BUILD_TYPE="Release"
             shift
             ;;
+        --no-vulkan)
+            VULKAN_ENABLED="OFF"
+            shift
+            ;;
         --abi)
             ABIS="$2"
             shift 2
@@ -46,6 +51,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --clean    Remove previous build artifacts before building"
             echo "  --debug    Build with debug symbols (default: Release)"
             echo "  --release  Build optimized release binary (default)"
+            echo "  --no-vulkan Disable Vulkan GPU backend (default: enabled)"
             echo "  --abi      Space-separated list of ABIs (default: arm64-v8a armeabi-v7a x86_64)"
             echo "  -h, --help Show this help message"
             echo ""
@@ -65,6 +71,7 @@ done
 echo "=== Edge Veda Android Build ==="
 echo "Build type: $BUILD_TYPE"
 echo "Target ABIs: $ABIS"
+echo "Vulkan: $VULKAN_ENABLED"
 echo "Project root: $PROJECT_ROOT"
 
 # ============================================================================
@@ -156,7 +163,7 @@ for abi in $ABIS; do
         -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
         -DEDGE_VEDA_BUILD_SHARED=ON \
         -DEDGE_VEDA_BUILD_STATIC=OFF \
-        -DEDGE_VEDA_ENABLE_VULKAN=OFF \
+        -DEDGE_VEDA_ENABLE_VULKAN=$VULKAN_ENABLED \
         -DEDGE_VEDA_ENABLE_CPU=ON \
         -DGGML_OPENMP=OFF
 


### PR DESCRIPTION
## Summary

- **Build system**: Enable ggml Vulkan backend via `EDGE_VEDA_ENABLE_VULKAN=ON` in CMake, Gradle, and build-android.sh (with `--no-vulkan` opt-out)
- **Runtime detection**: `ev_detect_backend()` probes actual Vulkan hardware via `ggml_backend_vk_get_device_count()` on Android/Linux/Windows, with transparent CPU fallback
- **Driver denylist**: Blocks known-broken GPUs (Adreno 5xx, PowerVR) with graceful CPU fallback
- **VRAM heuristic**: 40% VRAM budget on integrated GPUs for safe auto layer offload — prevents OOM on mobile
- **Flutter SDK**: `EdgeVedaConfig.useVulkan` flag (default true) wired through worker isolate to native backend selection
- **Dart FFI**: `EvBackend.vulkan(2)` added to match C `EV_BACKEND_VULKAN=2` enum

Closes community feedback: "gpu acceleration using vulkan on non-apple platforms"

## Test plan

- [ ] `flutter analyze` passes with no errors
- [ ] Android build compiles with Vulkan enabled (`GGML_VULKAN=ON` in CMake output)
- [ ] `build-android.sh` defaults to Vulkan ON, `--no-vulkan` disables it
- [ ] On Vulkan-capable device: inference runs on GPU with higher throughput than CPU-only
- [ ] On device without Vulkan: transparent CPU fallback, no crash
- [ ] `useVulkan: false` forces CPU backend on Vulkan-capable device
- [ ] Adreno 5xx device: denylist blocks Vulkan, falls back to CPU