### PR TITLE
feat: boilerplate-free tool-calling API with auto-dispatch

### DIFF
--- a/flutter/lib/edge_veda.dart
+++ b/flutter/lib/edge_veda.dart
@@ -168,6 +168,9 @@ export 'src/tool_registry.dart' show ToolRegistry;
 
 export 'src/tool_template.dart' show ToolTemplate;
 
+export 'src/param_builder.dart' show Param, ParamSchema;
+export 'src/tool.dart' show Tool;
+
 export 'src/schema_validator.dart'
     show SchemaValidator, SchemaValidationResult, SchemaValidationMode;
 

--- a/flutter/lib/src/chat_session.dart
+++ b/flutter/lib/src/chat_session.dart
@@ -43,6 +43,7 @@ import 'edge_veda_impl.dart';
 import 'gbnf_builder.dart';
 import 'json_recovery.dart';
 import 'schema_validator.dart';
+import 'tool.dart';
 import 'tool_registry.dart';
 import 'tool_template.dart';
 import 'tool_types.dart';
@@ -458,6 +459,238 @@ class ChatSession {
       }
       rethrow;
     }
+  }
+
+  /// Send a message with automatic tool dispatch and grammar-constrained output.
+  ///
+  /// This is the high-level tool calling API. Unlike [sendWithTools] which
+  /// requires an [onToolCall] callback, `chat()` accepts declarative [Tool]
+  /// objects that bundle their handler. Tool calls are dispatched automatically
+  /// in a multi-round loop.
+  ///
+  /// When [tools] is null or empty, delegates to [send] (no regression).
+  ///
+  /// Grammar constraining guarantees the model produces valid JSON for tool
+  /// calls, eliminating parse failures from malformed output.
+  ///
+  /// [maxToolRounds] limits consecutive tool call rounds (default 3).
+  ///
+  /// Example:
+  /// ```dart
+  /// final reply = await session.chat(
+  ///   'What is the weather in Tokyo?',
+  ///   tools: [weatherTool],
+  /// );
+  /// print(reply.content); // "The weather in Tokyo is 22C and sunny."
+  /// ```
+  Future<ChatMessage> chat(
+    String prompt, {
+    List<Tool>? tools,
+    GenerateOptions? options,
+    CancelToken? cancelToken,
+    int maxToolRounds = 3,
+  }) async {
+    // No tools -- delegate to send() for zero-overhead path
+    if (tools == null || tools.isEmpty) {
+      return send(prompt, options: options, cancelToken: cancelToken);
+    }
+
+    // Build lookup map and definitions
+    final toolMap = {for (final t in tools) t.name: t};
+    final definitions = tools.map((t) => t.toDefinition()).toList();
+
+    // Build grammar for constrained tool call output
+    final grammar = _buildToolCallGrammar(tools);
+
+    // Add user message
+    _messages.add(
+      ChatMessage(
+        role: ChatRole.user,
+        content: prompt,
+        timestamp: DateTime.now(),
+      ),
+    );
+
+    try {
+      // Check and summarize if needed
+      await _summarizeIfNeeded(cancelToken: cancelToken);
+
+      for (int round = 0; round < maxToolRounds; round++) {
+        // Format conversation with tool definitions
+        final formatted = _formatConversationWithToolsList(definitions);
+
+        // Grammar-constrained options for tool call output
+        final grammarOptions = (options ?? const GenerateOptions()).copyWith(
+          grammarStr: grammar,
+          grammarRoot: 'root',
+        );
+
+        // Generate response with grammar constraining
+        final response = await _edgeVeda.generate(
+          formatted,
+          options: grammarOptions,
+        );
+
+        // Parse tool calls from model output
+        var toolCalls = ToolTemplate.parseToolCalls(
+          format: templateFormat,
+          output: response.text,
+        );
+
+        // Fallback: if parseToolCalls returns null but grammar forced JSON,
+        // try direct JSON decode (handles Qwen3 grammar override of XML tags)
+        if (toolCalls == null || toolCalls.isEmpty) {
+          try {
+            final json =
+                jsonDecode(response.text.trim()) as Map<String, dynamic>;
+            if (json.containsKey('name')) {
+              final name = json['name'] as String;
+              final argsKey = json.containsKey('parameters')
+                  ? 'parameters'
+                  : 'arguments';
+              final arguments =
+                  (json[argsKey] ?? <String, dynamic>{}) as Map<String, dynamic>;
+              toolCalls = [ToolCall(name: name, arguments: arguments)];
+            }
+          } catch (_) {
+            // Not valid JSON -- treat as normal text response
+          }
+        }
+
+        if (toolCalls == null || toolCalls.isEmpty) {
+          // No tool call -- model gave final text response
+          final assistantMsg = ChatMessage(
+            role: ChatRole.assistant,
+            content: response.text,
+            timestamp: DateTime.now(),
+          );
+          _messages.add(assistantMsg);
+          return assistantMsg;
+        }
+
+        // Process the first tool call
+        final toolCall = toolCalls.first;
+
+        // Add tool call message to history
+        _messages.add(
+          ChatMessage(
+            role: ChatRole.toolCall,
+            content: jsonEncode({
+              'name': toolCall.name,
+              'arguments': toolCall.arguments,
+            }),
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        // Dispatch to the tool handler
+        final tool = toolMap[toolCall.name];
+        final ToolResult toolResult;
+        if (tool != null) {
+          toolResult = await tool.execute(toolCall);
+        } else {
+          toolResult = ToolResult.failure(
+            toolCallId: toolCall.id,
+            error: 'Unknown tool: ${toolCall.name}',
+          );
+        }
+
+        // Add tool result message to history
+        _messages.add(
+          ChatMessage(
+            role: ChatRole.toolResult,
+            content: toolResult.isError
+                ? jsonEncode({'error': toolResult.error})
+                : jsonEncode(toolResult.data),
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        // Continue loop -- model will see the result and may call
+        // another tool or produce a final response.
+      }
+
+      // Max rounds exhausted -- final generation WITHOUT grammar constraining
+      final formatted = _formatConversationWithToolsList(definitions);
+      final finalResponse = await _edgeVeda.generate(
+        formatted,
+        options: options,
+      );
+      final assistantMsg = ChatMessage(
+        role: ChatRole.assistant,
+        content: finalResponse.text,
+        timestamp: DateTime.now(),
+      );
+      _messages.add(assistantMsg);
+      return assistantMsg;
+    } catch (e) {
+      // Rollback user message on error
+      if (_messages.isNotEmpty && _messages.last.role == ChatRole.user) {
+        _messages.removeLast();
+      }
+      rethrow;
+    }
+  }
+
+  /// Build a GBNF grammar constraining model output to valid tool call JSON.
+  ///
+  /// Adapts the arguments field name based on [templateFormat]:
+  /// - Gemma3 uses `'parameters'`
+  /// - Qwen3 and others use `'arguments'`
+  String _buildToolCallGrammar(List<Tool> tools) {
+    final argsFieldName = templateFormat == ChatTemplateFormat.gemma3
+        ? 'parameters'
+        : 'arguments';
+
+    final Map<String, dynamic> schema;
+    if (tools.length == 1) {
+      // Single tool: constrain name to exact match and args to tool schema
+      final tool = tools.first;
+      schema = {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'type': 'string',
+            'enum': [tool.name],
+          },
+          argsFieldName: tool.parameters.toJsonSchema(),
+        },
+        'required': ['name', argsFieldName],
+      };
+    } else {
+      // Multiple tools: constrain name to valid tool names, args to any object
+      // (GbnfBuilder does not support oneOf/anyOf)
+      schema = {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'type': 'string',
+            'enum': tools.map((t) => t.name).toList(),
+          },
+          argsFieldName: {'type': 'object'},
+        },
+        'required': ['name', argsFieldName],
+      };
+    }
+
+    return GbnfBuilder.fromJsonSchema(schema);
+  }
+
+  /// Format conversation with an explicit tool definitions list.
+  ///
+  /// Unlike [_formatConversationWithTools] which uses the constructor's
+  /// [_tools] field, this takes an inline list for use with [chat].
+  String _formatConversationWithToolsList(List<ToolDefinition> tools) {
+    final toolSystemPrompt = ToolTemplate.formatToolSystemPrompt(
+      format: templateFormat,
+      tools: tools,
+      systemPrompt: systemPrompt,
+    );
+    return ChatTemplate.format(
+      template: templateFormat,
+      systemPrompt: toolSystemPrompt,
+      messages: _messages,
+    );
   }
 
   /// Send a message and get a structured JSON response validated

--- a/flutter/lib/src/chat_session.dart
+++ b/flutter/lib/src/chat_session.dart
@@ -545,11 +545,11 @@ class ChatSession {
                 jsonDecode(response.text.trim()) as Map<String, dynamic>;
             if (json.containsKey('name')) {
               final name = json['name'] as String;
-              final argsKey = json.containsKey('parameters')
-                  ? 'parameters'
-                  : 'arguments';
+              final argsKey =
+                  json.containsKey('parameters') ? 'parameters' : 'arguments';
               final arguments =
-                  (json[argsKey] ?? <String, dynamic>{}) as Map<String, dynamic>;
+                  (json[argsKey] ?? <String, dynamic>{})
+                      as Map<String, dynamic>;
               toolCalls = [ToolCall(name: name, arguments: arguments)];
             }
           } catch (_) {
@@ -599,9 +599,10 @@ class ChatSession {
         _messages.add(
           ChatMessage(
             role: ChatRole.toolResult,
-            content: toolResult.isError
-                ? jsonEncode({'error': toolResult.error})
-                : jsonEncode(toolResult.data),
+            content:
+                toolResult.isError
+                    ? jsonEncode({'error': toolResult.error})
+                    : jsonEncode(toolResult.data),
             timestamp: DateTime.now(),
           ),
         );
@@ -638,9 +639,10 @@ class ChatSession {
   /// - Gemma3 uses `'parameters'`
   /// - Qwen3 and others use `'arguments'`
   String _buildToolCallGrammar(List<Tool> tools) {
-    final argsFieldName = templateFormat == ChatTemplateFormat.gemma3
-        ? 'parameters'
-        : 'arguments';
+    final argsFieldName =
+        templateFormat == ChatTemplateFormat.gemma3
+            ? 'parameters'
+            : 'arguments';
 
     final Map<String, dynamic> schema;
     if (tools.length == 1) {
@@ -663,10 +665,7 @@ class ChatSession {
       schema = {
         'type': 'object',
         'properties': {
-          'name': {
-            'type': 'string',
-            'enum': tools.map((t) => t.name).toList(),
-          },
+          'name': {'type': 'string', 'enum': tools.map((t) => t.name).toList()},
           argsFieldName: {'type': 'object'},
         },
         'required': ['name', argsFieldName],

--- a/flutter/lib/src/param_builder.dart
+++ b/flutter/lib/src/param_builder.dart
@@ -1,0 +1,139 @@
+/// Type-safe JSON Schema builder for tool parameter definitions.
+///
+/// Replaces raw `Map<String, dynamic>` JSON Schema construction with
+/// a declarative [Param] factory that produces validated [ParamSchema]
+/// objects compatible with [ToolDefinition] and [GbnfBuilder].
+library;
+
+/// Wraps a JSON Schema map with an immutable accessor.
+///
+/// Created exclusively via [Param] static factories. The underlying
+/// schema map is returned as unmodifiable from [toJsonSchema].
+class ParamSchema {
+  final Map<String, dynamic> _schema;
+
+  const ParamSchema._(this._schema);
+
+  /// Returns an unmodifiable view of the JSON Schema map.
+  ///
+  /// The returned map is compatible with [ToolDefinition.parameters]
+  /// and [GbnfBuilder.fromJsonSchema].
+  Map<String, dynamic> toJsonSchema() => Map.unmodifiable(_schema);
+}
+
+/// Static factory for building [ParamSchema] instances.
+///
+/// Provides type-safe constructors for each JSON Schema primitive type,
+/// plus `array` and `object` composites. Only includes optional keys
+/// when the corresponding parameter is non-null, keeping schemas minimal.
+///
+/// Example:
+/// ```dart
+/// final params = Param.object({
+///   'location': Param.string(description: 'City name'),
+///   'unit': Param.string(
+///     description: 'Temperature unit',
+///     enumValues: ['celsius', 'fahrenheit'],
+///   ),
+/// }, required: ['location']);
+/// ```
+class Param {
+  Param._();
+
+  /// Creates a string parameter schema.
+  ///
+  /// If [enumValues] is provided, adds an `'enum'` constraint.
+  static ParamSchema string({String? description, List<String>? enumValues}) {
+    final schema = <String, dynamic>{'type': 'string'};
+    if (description != null) schema['description'] = description;
+    if (enumValues != null) schema['enum'] = enumValues;
+    return ParamSchema._(schema);
+  }
+
+  /// Creates an integer parameter schema.
+  ///
+  /// [minimum] and [maximum] are included for documentation and
+  /// post-generation validation. GBNF grammar cannot enforce numeric
+  /// range constraints.
+  static ParamSchema integer({
+    String? description,
+    int? minimum,
+    int? maximum,
+  }) {
+    final schema = <String, dynamic>{'type': 'integer'};
+    if (description != null) schema['description'] = description;
+    if (minimum != null) schema['minimum'] = minimum;
+    if (maximum != null) schema['maximum'] = maximum;
+    return ParamSchema._(schema);
+  }
+
+  /// Creates a number (floating-point) parameter schema.
+  ///
+  /// [minimum] and [maximum] are included for documentation and
+  /// post-generation validation. GBNF grammar cannot enforce numeric
+  /// range constraints.
+  static ParamSchema number({
+    String? description,
+    num? minimum,
+    num? maximum,
+  }) {
+    final schema = <String, dynamic>{'type': 'number'};
+    if (description != null) schema['description'] = description;
+    if (minimum != null) schema['minimum'] = minimum;
+    if (maximum != null) schema['maximum'] = maximum;
+    return ParamSchema._(schema);
+  }
+
+  /// Creates a boolean parameter schema.
+  static ParamSchema boolean({String? description}) {
+    final schema = <String, dynamic>{'type': 'boolean'};
+    if (description != null) schema['description'] = description;
+    return ParamSchema._(schema);
+  }
+
+  /// Creates an array parameter schema.
+  ///
+  /// [items] defines the schema for each array element.
+  /// [minItems] and [maxItems] are included for documentation and
+  /// post-generation validation.
+  static ParamSchema array({
+    required ParamSchema items,
+    String? description,
+    int? minItems,
+    int? maxItems,
+  }) {
+    final schema = <String, dynamic>{
+      'type': 'array',
+      'items': items.toJsonSchema(),
+    };
+    if (description != null) schema['description'] = description;
+    if (minItems != null) schema['minItems'] = minItems;
+    if (maxItems != null) schema['maxItems'] = maxItems;
+    return ParamSchema._(schema);
+  }
+
+  /// Creates an object parameter schema.
+  ///
+  /// [properties] maps property names to their [ParamSchema] definitions.
+  /// [required] lists which properties are mandatory.
+  static ParamSchema object(
+    Map<String, ParamSchema> properties, {
+    List<String>? required,
+    String? description,
+  }) {
+    final schemaProperties = <String, dynamic>{};
+    for (final entry in properties.entries) {
+      schemaProperties[entry.key] = entry.value.toJsonSchema();
+    }
+
+    final schema = <String, dynamic>{
+      'type': 'object',
+      'properties': schemaProperties,
+    };
+    if (description != null) schema['description'] = description;
+    if (required != null && required.isNotEmpty) {
+      schema['required'] = required;
+    }
+    return ParamSchema._(schema);
+  }
+}

--- a/flutter/lib/src/param_builder.dart
+++ b/flutter/lib/src/param_builder.dart
@@ -72,11 +72,7 @@ class Param {
   /// [minimum] and [maximum] are included for documentation and
   /// post-generation validation. GBNF grammar cannot enforce numeric
   /// range constraints.
-  static ParamSchema number({
-    String? description,
-    num? minimum,
-    num? maximum,
-  }) {
+  static ParamSchema number({String? description, num? minimum, num? maximum}) {
     final schema = <String, dynamic>{'type': 'number'};
     if (description != null) schema['description'] = description;
     if (minimum != null) schema['minimum'] = minimum;

--- a/flutter/lib/src/tool.dart
+++ b/flutter/lib/src/tool.dart
@@ -48,7 +48,7 @@ class Tool {
 
   /// Async handler that receives parsed arguments and returns result data.
   final Future<Map<String, dynamic>> Function(Map<String, dynamic> args)
-      handler;
+  handler;
 
   /// Priority for budget-aware degradation (default: [ToolPriority.required]).
   final ToolPriority priority;
@@ -70,11 +70,11 @@ class Tool {
   /// Validation fires here (name pattern, non-empty description,
   /// parameters must have 'type': 'object').
   ToolDefinition toDefinition() => ToolDefinition(
-        name: name,
-        description: description,
-        parameters: parameters.toJsonSchema(),
-        priority: priority,
-      );
+    name: name,
+    description: description,
+    parameters: parameters.toJsonSchema(),
+    priority: priority,
+  );
 
   /// Execute this tool with the given [call] arguments.
   ///

--- a/flutter/lib/src/tool.dart
+++ b/flutter/lib/src/tool.dart
@@ -1,0 +1,92 @@
+/// Declarative tool class that bundles definition and handler.
+///
+/// Combines tool metadata ([name], [description], [parameters]) with an
+/// async [handler] function, providing a single object that can both
+/// describe itself to the model (via [toDefinition]) and execute calls
+/// (via [execute]) with built-in error safety.
+library;
+
+import 'param_builder.dart';
+import 'tool_types.dart';
+
+/// A declarative tool that combines its JSON Schema definition with
+/// an async execution handler.
+///
+/// Use [toDefinition] to register with [ToolRegistry], and [execute]
+/// to safely invoke the handler with error wrapping.
+///
+/// Example:
+/// ```dart
+/// final weatherTool = Tool(
+///   name: 'get_weather',
+///   description: 'Get current weather for a location',
+///   parameters: Param.object({
+///     'location': Param.string(description: 'City name'),
+///     'unit': Param.string(enumValues: ['celsius', 'fahrenheit']),
+///   }, required: ['location']),
+///   handler: (args) async {
+///     final city = args['location'] as String;
+///     return {'temperature': 22, 'unit': 'celsius', 'city': city};
+///   },
+/// );
+///
+/// // Register with ToolRegistry
+/// final registry = ToolRegistry([weatherTool.toDefinition()]);
+///
+/// // Execute a tool call
+/// final result = await weatherTool.execute(toolCall);
+/// ```
+class Tool {
+  /// Tool function name (validated by [ToolDefinition] on [toDefinition]).
+  final String name;
+
+  /// Human-readable description shown to the model.
+  final String description;
+
+  /// Parameter schema built via [Param] factories.
+  final ParamSchema parameters;
+
+  /// Async handler that receives parsed arguments and returns result data.
+  final Future<Map<String, dynamic>> Function(Map<String, dynamic> args)
+      handler;
+
+  /// Priority for budget-aware degradation (default: [ToolPriority.required]).
+  final ToolPriority priority;
+
+  /// Create a declarative tool with embedded handler.
+  ///
+  /// Validation of [name], [description], and [parameters] is deferred
+  /// to [toDefinition], which delegates to [ToolDefinition]'s constructor.
+  Tool({
+    required this.name,
+    required this.description,
+    required this.parameters,
+    required this.handler,
+    this.priority = ToolPriority.required,
+  });
+
+  /// Convert to a [ToolDefinition] for registration with [ToolRegistry].
+  ///
+  /// Validation fires here (name pattern, non-empty description,
+  /// parameters must have 'type': 'object').
+  ToolDefinition toDefinition() => ToolDefinition(
+        name: name,
+        description: description,
+        parameters: parameters.toJsonSchema(),
+        priority: priority,
+      );
+
+  /// Execute this tool with the given [call] arguments.
+  ///
+  /// Wraps [handler] in a try/catch so that handler exceptions never
+  /// crash the calling inference loop. Returns [ToolResult.success] on
+  /// normal completion, [ToolResult.failure] on any exception.
+  Future<ToolResult> execute(ToolCall call) async {
+    try {
+      final result = await handler(call.arguments);
+      return ToolResult.success(toolCallId: call.id, data: result);
+    } catch (e) {
+      return ToolResult.failure(toolCallId: call.id, error: e.toString());
+    }
+  }
+}

--- a/flutter/test/chat_session_tool_test.dart
+++ b/flutter/test/chat_session_tool_test.dart
@@ -1,0 +1,296 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:edge_veda/edge_veda.dart';
+
+void main() {
+  group('Export verification', () {
+    test('Tool, Param, ParamSchema are importable from edge_veda.dart', () {
+      // If this compiles and runs, the exports work.
+      final schema = Param.object({
+        'city': Param.string(description: 'City name'),
+      }, required: ['city']);
+
+      final tool = Tool(
+        name: 'test_tool',
+        description: 'A test tool',
+        parameters: schema,
+        handler: (args) async => {'ok': true},
+      );
+
+      expect(tool.name, 'test_tool');
+      expect(schema, isA<ParamSchema>());
+    });
+  });
+
+  group('Param -> ToolDefinition -> GbnfBuilder integration', () {
+    test('single-tool schema produces valid GBNF with tool name', () {
+      final tool = Tool(
+        name: 'get_weather',
+        description: 'Get weather info',
+        parameters: Param.object({
+          'location': Param.string(description: 'City name'),
+          'unit': Param.string(enumValues: ['celsius', 'fahrenheit']),
+        }, required: ['location']),
+        handler: (args) async => {},
+      );
+
+      // Build schema the same way chat() does for a single tool
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'type': 'string',
+            'enum': [tool.name],
+          },
+          'arguments': tool.parameters.toJsonSchema(),
+        },
+        'required': ['name', 'arguments'],
+      };
+
+      final gbnf = GbnfBuilder.fromJsonSchema(schema);
+      expect(gbnf, isNotEmpty);
+      expect(gbnf, contains('root'));
+      expect(gbnf, contains('get_weather'));
+    });
+
+    test('multi-tool schema produces GBNF with all tool names', () {
+      final tools = [
+        Tool(
+          name: 'get_weather',
+          description: 'Get weather',
+          parameters: Param.object({
+            'location': Param.string(),
+          }, required: ['location']),
+          handler: (args) async => {},
+        ),
+        Tool(
+          name: 'search_web',
+          description: 'Search the web',
+          parameters: Param.object({
+            'query': Param.string(),
+          }, required: ['query']),
+          handler: (args) async => {},
+        ),
+      ];
+
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'type': 'string',
+            'enum': tools.map((t) => t.name).toList(),
+          },
+          'arguments': {'type': 'object'},
+        },
+        'required': ['name', 'arguments'],
+      };
+
+      final gbnf = GbnfBuilder.fromJsonSchema(schema);
+      expect(gbnf, isNotEmpty);
+      expect(gbnf, contains('get_weather'));
+      expect(gbnf, contains('search_web'));
+    });
+
+    test('complex nested Param flows through to valid GBNF', () {
+      final tool = Tool(
+        name: 'complex_tool',
+        description: 'Complex tool',
+        parameters: Param.object({
+          'query': Param.string(description: 'Search query'),
+          'limit': Param.integer(minimum: 1, maximum: 100),
+          'filters': Param.object({
+            'category': Param.string(enumValues: ['a', 'b', 'c']),
+            'active': Param.boolean(),
+          }),
+          'tags': Param.array(items: Param.string()),
+        }, required: ['query']),
+        handler: (args) async => {},
+      );
+
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'type': 'string',
+            'enum': [tool.name],
+          },
+          'arguments': tool.parameters.toJsonSchema(),
+        },
+        'required': ['name', 'arguments'],
+      };
+
+      final gbnf = GbnfBuilder.fromJsonSchema(schema);
+      expect(gbnf, isNotEmpty);
+      expect(gbnf, contains('root'));
+      // Should have rules for nested object and array
+      expect(gbnf, contains('obj'));
+      expect(gbnf, contains('arr'));
+    });
+  });
+
+  group('Gemma3 vs Qwen3 field naming', () {
+    test('Gemma3 format uses "parameters" field name', () {
+      final tool = Tool(
+        name: 'my_tool',
+        description: 'A tool',
+        parameters: Param.object({
+          'x': Param.string(),
+        }),
+        handler: (args) async => {},
+      );
+
+      // Gemma3 schema uses 'parameters'
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'type': 'string',
+            'enum': [tool.name],
+          },
+          'parameters': tool.parameters.toJsonSchema(),
+        },
+        'required': ['name', 'parameters'],
+      };
+
+      final gbnf = GbnfBuilder.fromJsonSchema(schema);
+      expect(gbnf, isNotEmpty);
+      expect(gbnf, contains('parameters'));
+    });
+
+    test('Qwen3 format uses "arguments" field name', () {
+      final tool = Tool(
+        name: 'my_tool',
+        description: 'A tool',
+        parameters: Param.object({
+          'x': Param.string(),
+        }),
+        handler: (args) async => {},
+      );
+
+      // Qwen3 schema uses 'arguments'
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'name': {
+            'type': 'string',
+            'enum': [tool.name],
+          },
+          'arguments': tool.parameters.toJsonSchema(),
+        },
+        'required': ['name', 'arguments'],
+      };
+
+      final gbnf = GbnfBuilder.fromJsonSchema(schema);
+      expect(gbnf, isNotEmpty);
+      expect(gbnf, contains('arguments'));
+    });
+  });
+
+  group('Tool dispatch error handling', () {
+    test('handler exception produces ToolResult.failure', () async {
+      final failTool = Tool(
+        name: 'fail_tool',
+        description: 'Always fails',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async {
+          throw Exception('Network timeout');
+        },
+      );
+
+      final call = ToolCall(name: 'fail_tool', arguments: {'x': 'test'});
+      final result = await failTool.execute(call);
+      expect(result.isError, true);
+      expect(result.error, contains('Network timeout'));
+      expect(result.toolCallId, call.id);
+    });
+
+    test('successful handler produces ToolResult.success', () async {
+      final okTool = Tool(
+        name: 'ok_tool',
+        description: 'Always succeeds',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async => {'result': args['x']},
+      );
+
+      final call = ToolCall(name: 'ok_tool', arguments: {'x': 'hello'});
+      final result = await okTool.execute(call);
+      expect(result.isError, false);
+      expect(result.data!['result'], 'hello');
+    });
+  });
+
+  group('ToolTemplate integration', () {
+    test('Param-built definitions format into Qwen3 system prompt', () {
+      final tool = Tool(
+        name: 'get_weather',
+        description: 'Get current weather',
+        parameters: Param.object({
+          'location': Param.string(description: 'City name'),
+        }, required: ['location']),
+        handler: (args) async => {},
+      );
+
+      final def = tool.toDefinition();
+      final prompt = ToolTemplate.formatToolSystemPrompt(
+        format: ChatTemplateFormat.qwen3,
+        tools: [def],
+        systemPrompt: 'You are helpful.',
+      );
+
+      expect(prompt, contains('<tools>'));
+      expect(prompt, contains('get_weather'));
+      expect(prompt, contains('Get current weather'));
+      expect(prompt, contains('You are helpful.'));
+    });
+
+    test('Param-built definitions format into Gemma3 system prompt', () {
+      final tool = Tool(
+        name: 'search',
+        description: 'Search the web',
+        parameters: Param.object({
+          'query': Param.string(),
+        }, required: ['query']),
+        handler: (args) async => {},
+      );
+
+      final def = tool.toDefinition();
+      final prompt = ToolTemplate.formatToolSystemPrompt(
+        format: ChatTemplateFormat.gemma3,
+        tools: [def],
+      );
+
+      expect(prompt, contains('search'));
+      expect(prompt, contains('Search the web'));
+      expect(prompt, contains('"name"'));
+    });
+
+    test('parseToolCalls extracts Qwen3-style tool call', () {
+      final output =
+          '<tool_call>\n{"name": "get_weather", "arguments": {"location": "Tokyo"}}\n</tool_call>';
+      final calls = ToolTemplate.parseToolCalls(
+        format: ChatTemplateFormat.qwen3,
+        output: output,
+      );
+
+      expect(calls, isNotNull);
+      expect(calls!.length, 1);
+      expect(calls.first.name, 'get_weather');
+      expect(calls.first.arguments['location'], 'Tokyo');
+    });
+
+    test('parseToolCalls extracts Gemma3-style tool call', () {
+      final output =
+          '{"name": "search", "parameters": {"query": "flutter"}}';
+      final calls = ToolTemplate.parseToolCalls(
+        format: ChatTemplateFormat.gemma3,
+        output: output,
+      );
+
+      expect(calls, isNotNull);
+      expect(calls!.length, 1);
+      expect(calls.first.name, 'search');
+      expect(calls.first.arguments['query'], 'flutter');
+    });
+  });
+}

--- a/flutter/test/chat_session_tool_test.dart
+++ b/flutter/test/chat_session_tool_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:edge_veda/edge_veda.dart';
 
@@ -270,7 +268,7 @@ void main() {
     });
 
     test('parseToolCalls extracts Qwen3-style tool call', () {
-      final output =
+      const output =
           '<tool_call>\n{"name": "get_weather", "arguments": {"location": "Tokyo"}}\n</tool_call>';
       final calls = ToolTemplate.parseToolCalls(
         format: ChatTemplateFormat.qwen3,
@@ -284,7 +282,7 @@ void main() {
     });
 
     test('parseToolCalls extracts Gemma3-style tool call', () {
-      final output = '{"name": "search", "parameters": {"query": "flutter"}}';
+      const output = '{"name": "search", "parameters": {"query": "flutter"}}';
       final calls = ToolTemplate.parseToolCalls(
         format: ChatTemplateFormat.gemma3,
         output: output,

--- a/flutter/test/chat_session_tool_test.dart
+++ b/flutter/test/chat_session_tool_test.dart
@@ -7,9 +7,10 @@ void main() {
   group('Export verification', () {
     test('Tool, Param, ParamSchema are importable from edge_veda.dart', () {
       // If this compiles and runs, the exports work.
-      final schema = Param.object({
-        'city': Param.string(description: 'City name'),
-      }, required: ['city']);
+      final schema = Param.object(
+        {'city': Param.string(description: 'City name')},
+        required: ['city'],
+      );
 
       final tool = Tool(
         name: 'test_tool',
@@ -28,10 +29,13 @@ void main() {
       final tool = Tool(
         name: 'get_weather',
         description: 'Get weather info',
-        parameters: Param.object({
-          'location': Param.string(description: 'City name'),
-          'unit': Param.string(enumValues: ['celsius', 'fahrenheit']),
-        }, required: ['location']),
+        parameters: Param.object(
+          {
+            'location': Param.string(description: 'City name'),
+            'unit': Param.string(enumValues: ['celsius', 'fahrenheit']),
+          },
+          required: ['location'],
+        ),
         handler: (args) async => {},
       );
 
@@ -59,17 +63,19 @@ void main() {
         Tool(
           name: 'get_weather',
           description: 'Get weather',
-          parameters: Param.object({
-            'location': Param.string(),
-          }, required: ['location']),
+          parameters: Param.object(
+            {'location': Param.string()},
+            required: ['location'],
+          ),
           handler: (args) async => {},
         ),
         Tool(
           name: 'search_web',
           description: 'Search the web',
-          parameters: Param.object({
-            'query': Param.string(),
-          }, required: ['query']),
+          parameters: Param.object(
+            {'query': Param.string()},
+            required: ['query'],
+          ),
           handler: (args) async => {},
         ),
       ];
@@ -77,10 +83,7 @@ void main() {
       final schema = {
         'type': 'object',
         'properties': {
-          'name': {
-            'type': 'string',
-            'enum': tools.map((t) => t.name).toList(),
-          },
+          'name': {'type': 'string', 'enum': tools.map((t) => t.name).toList()},
           'arguments': {'type': 'object'},
         },
         'required': ['name', 'arguments'],
@@ -96,15 +99,18 @@ void main() {
       final tool = Tool(
         name: 'complex_tool',
         description: 'Complex tool',
-        parameters: Param.object({
-          'query': Param.string(description: 'Search query'),
-          'limit': Param.integer(minimum: 1, maximum: 100),
-          'filters': Param.object({
-            'category': Param.string(enumValues: ['a', 'b', 'c']),
-            'active': Param.boolean(),
-          }),
-          'tags': Param.array(items: Param.string()),
-        }, required: ['query']),
+        parameters: Param.object(
+          {
+            'query': Param.string(description: 'Search query'),
+            'limit': Param.integer(minimum: 1, maximum: 100),
+            'filters': Param.object({
+              'category': Param.string(enumValues: ['a', 'b', 'c']),
+              'active': Param.boolean(),
+            }),
+            'tags': Param.array(items: Param.string()),
+          },
+          required: ['query'],
+        ),
         handler: (args) async => {},
       );
 
@@ -134,9 +140,7 @@ void main() {
       final tool = Tool(
         name: 'my_tool',
         description: 'A tool',
-        parameters: Param.object({
-          'x': Param.string(),
-        }),
+        parameters: Param.object({'x': Param.string()}),
         handler: (args) async => {},
       );
 
@@ -162,9 +166,7 @@ void main() {
       final tool = Tool(
         name: 'my_tool',
         description: 'A tool',
-        parameters: Param.object({
-          'x': Param.string(),
-        }),
+        parameters: Param.object({'x': Param.string()}),
         handler: (args) async => {},
       );
 
@@ -225,9 +227,10 @@ void main() {
       final tool = Tool(
         name: 'get_weather',
         description: 'Get current weather',
-        parameters: Param.object({
-          'location': Param.string(description: 'City name'),
-        }, required: ['location']),
+        parameters: Param.object(
+          {'location': Param.string(description: 'City name')},
+          required: ['location'],
+        ),
         handler: (args) async => {},
       );
 
@@ -248,9 +251,10 @@ void main() {
       final tool = Tool(
         name: 'search',
         description: 'Search the web',
-        parameters: Param.object({
-          'query': Param.string(),
-        }, required: ['query']),
+        parameters: Param.object(
+          {'query': Param.string()},
+          required: ['query'],
+        ),
         handler: (args) async => {},
       );
 
@@ -280,8 +284,7 @@ void main() {
     });
 
     test('parseToolCalls extracts Gemma3-style tool call', () {
-      final output =
-          '{"name": "search", "parameters": {"query": "flutter"}}';
+      final output = '{"name": "search", "parameters": {"query": "flutter"}}';
       final calls = ToolTemplate.parseToolCalls(
         format: ChatTemplateFormat.gemma3,
         output: output,

--- a/flutter/test/param_builder_test.dart
+++ b/flutter/test/param_builder_test.dart
@@ -1,0 +1,245 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:edge_veda/src/param_builder.dart';
+
+void main() {
+  group('Param.string', () {
+    test('produces minimal string schema', () {
+      final schema = Param.string().toJsonSchema();
+      expect(schema, {'type': 'string'});
+    });
+
+    test('includes description when provided', () {
+      final schema = Param.string(description: 'A city name').toJsonSchema();
+      expect(schema['type'], 'string');
+      expect(schema['description'], 'A city name');
+    });
+
+    test('includes enum when enumValues provided', () {
+      final schema = Param.string(
+        enumValues: ['celsius', 'fahrenheit'],
+      ).toJsonSchema();
+      expect(schema['type'], 'string');
+      expect(schema['enum'], ['celsius', 'fahrenheit']);
+    });
+
+    test('includes both description and enum', () {
+      final schema = Param.string(
+        description: 'Temperature unit',
+        enumValues: ['celsius', 'fahrenheit'],
+      ).toJsonSchema();
+      expect(schema['type'], 'string');
+      expect(schema['description'], 'Temperature unit');
+      expect(schema['enum'], ['celsius', 'fahrenheit']);
+    });
+  });
+
+  group('Param.integer', () {
+    test('produces minimal integer schema', () {
+      final schema = Param.integer().toJsonSchema();
+      expect(schema, {'type': 'integer'});
+    });
+
+    test('includes minimum and maximum when provided', () {
+      final schema = Param.integer(
+        description: 'Age',
+        minimum: 0,
+        maximum: 150,
+      ).toJsonSchema();
+      expect(schema['type'], 'integer');
+      expect(schema['description'], 'Age');
+      expect(schema['minimum'], 0);
+      expect(schema['maximum'], 150);
+    });
+
+    test('includes only minimum when maximum is null', () {
+      final schema = Param.integer(minimum: 1).toJsonSchema();
+      expect(schema['minimum'], 1);
+      expect(schema.containsKey('maximum'), false);
+    });
+  });
+
+  group('Param.number', () {
+    test('produces minimal number schema', () {
+      final schema = Param.number().toJsonSchema();
+      expect(schema, {'type': 'number'});
+    });
+
+    test('includes minimum and maximum when provided', () {
+      final schema = Param.number(
+        description: 'Temperature',
+        minimum: -273.15,
+        maximum: 1000,
+      ).toJsonSchema();
+      expect(schema['type'], 'number');
+      expect(schema['description'], 'Temperature');
+      expect(schema['minimum'], -273.15);
+      expect(schema['maximum'], 1000);
+    });
+  });
+
+  group('Param.boolean', () {
+    test('produces minimal boolean schema', () {
+      final schema = Param.boolean().toJsonSchema();
+      expect(schema, {'type': 'boolean'});
+    });
+
+    test('includes description when provided', () {
+      final schema = Param.boolean(
+        description: 'Whether to include details',
+      ).toJsonSchema();
+      expect(schema['type'], 'boolean');
+      expect(schema['description'], 'Whether to include details');
+    });
+  });
+
+  group('Param.array', () {
+    test('produces array schema with items', () {
+      final schema = Param.array(
+        items: Param.string(),
+      ).toJsonSchema();
+      expect(schema['type'], 'array');
+      expect(schema['items'], {'type': 'string'});
+    });
+
+    test('includes minItems and maxItems when provided', () {
+      final schema = Param.array(
+        items: Param.integer(),
+        description: 'List of scores',
+        minItems: 1,
+        maxItems: 10,
+      ).toJsonSchema();
+      expect(schema['type'], 'array');
+      expect(schema['items'], {'type': 'integer'});
+      expect(schema['description'], 'List of scores');
+      expect(schema['minItems'], 1);
+      expect(schema['maxItems'], 10);
+    });
+
+    test('omits minItems and maxItems when null', () {
+      final schema = Param.array(items: Param.string()).toJsonSchema();
+      expect(schema.containsKey('minItems'), false);
+      expect(schema.containsKey('maxItems'), false);
+    });
+  });
+
+  group('Param.object', () {
+    test('produces object schema with properties', () {
+      final schema = Param.object({
+        'name': Param.string(description: 'User name'),
+        'age': Param.integer(),
+      }).toJsonSchema();
+
+      expect(schema['type'], 'object');
+      final props = schema['properties'] as Map<String, dynamic>;
+      expect(props['name'], {'type': 'string', 'description': 'User name'});
+      expect(props['age'], {'type': 'integer'});
+    });
+
+    test('includes required list when provided', () {
+      final schema = Param.object({
+        'name': Param.string(),
+        'age': Param.integer(),
+      }, required: ['name']).toJsonSchema();
+
+      expect(schema['required'], ['name']);
+    });
+
+    test('omits required when null', () {
+      final schema = Param.object({
+        'name': Param.string(),
+      }).toJsonSchema();
+      expect(schema.containsKey('required'), false);
+    });
+
+    test('omits required when empty list', () {
+      final schema = Param.object({
+        'name': Param.string(),
+      }, required: []).toJsonSchema();
+      expect(schema.containsKey('required'), false);
+    });
+
+    test('includes description when provided', () {
+      final schema = Param.object({
+        'x': Param.number(),
+      }, description: 'Coordinate object').toJsonSchema();
+      expect(schema['description'], 'Coordinate object');
+    });
+  });
+
+  group('Nested schemas', () {
+    test('nested object inside object produces correct deep schema', () {
+      final schema = Param.object({
+        'address': Param.object({
+          'street': Param.string(description: 'Street address'),
+          'city': Param.string(description: 'City name'),
+          'zip': Param.string(),
+        }, required: ['street', 'city']),
+        'name': Param.string(),
+      }, required: ['name', 'address']).toJsonSchema();
+
+      expect(schema['type'], 'object');
+      expect(schema['required'], ['name', 'address']);
+
+      final props = schema['properties'] as Map<String, dynamic>;
+      final address = props['address'] as Map<String, dynamic>;
+      expect(address['type'], 'object');
+      expect(address['required'], ['street', 'city']);
+
+      final addressProps = address['properties'] as Map<String, dynamic>;
+      expect(addressProps['street'], {
+        'type': 'string',
+        'description': 'Street address',
+      });
+      expect(addressProps['city'], {
+        'type': 'string',
+        'description': 'City name',
+      });
+      expect(addressProps['zip'], {'type': 'string'});
+    });
+
+    test('array of objects produces correct nested schema', () {
+      final schema = Param.array(
+        items: Param.object({
+          'id': Param.integer(),
+          'label': Param.string(),
+        }, required: ['id']),
+      ).toJsonSchema();
+
+      expect(schema['type'], 'array');
+      final items = schema['items'] as Map<String, dynamic>;
+      expect(items['type'], 'object');
+      expect(items['required'], ['id']);
+      final itemProps = items['properties'] as Map<String, dynamic>;
+      expect(itemProps['id'], {'type': 'integer'});
+      expect(itemProps['label'], {'type': 'string'});
+    });
+  });
+
+  group('Schema minimality', () {
+    test('optional fields are omitted when null', () {
+      final stringSchema = Param.string().toJsonSchema();
+      expect(stringSchema.length, 1); // only 'type'
+      expect(stringSchema.containsKey('description'), false);
+      expect(stringSchema.containsKey('enum'), false);
+
+      final intSchema = Param.integer().toJsonSchema();
+      expect(intSchema.length, 1);
+      expect(intSchema.containsKey('minimum'), false);
+      expect(intSchema.containsKey('maximum'), false);
+
+      final numSchema = Param.number().toJsonSchema();
+      expect(numSchema.length, 1);
+
+      final boolSchema = Param.boolean().toJsonSchema();
+      expect(boolSchema.length, 1);
+    });
+
+    test('toJsonSchema returns unmodifiable map', () {
+      final schema = Param.string().toJsonSchema();
+      expect(
+        () => schema['extra'] = 'value',
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+}

--- a/flutter/test/param_builder_test.dart
+++ b/flutter/test/param_builder_test.dart
@@ -15,18 +15,18 @@ void main() {
     });
 
     test('includes enum when enumValues provided', () {
-      final schema = Param.string(
-        enumValues: ['celsius', 'fahrenheit'],
-      ).toJsonSchema();
+      final schema =
+          Param.string(enumValues: ['celsius', 'fahrenheit']).toJsonSchema();
       expect(schema['type'], 'string');
       expect(schema['enum'], ['celsius', 'fahrenheit']);
     });
 
     test('includes both description and enum', () {
-      final schema = Param.string(
-        description: 'Temperature unit',
-        enumValues: ['celsius', 'fahrenheit'],
-      ).toJsonSchema();
+      final schema =
+          Param.string(
+            description: 'Temperature unit',
+            enumValues: ['celsius', 'fahrenheit'],
+          ).toJsonSchema();
       expect(schema['type'], 'string');
       expect(schema['description'], 'Temperature unit');
       expect(schema['enum'], ['celsius', 'fahrenheit']);
@@ -40,11 +40,12 @@ void main() {
     });
 
     test('includes minimum and maximum when provided', () {
-      final schema = Param.integer(
-        description: 'Age',
-        minimum: 0,
-        maximum: 150,
-      ).toJsonSchema();
+      final schema =
+          Param.integer(
+            description: 'Age',
+            minimum: 0,
+            maximum: 150,
+          ).toJsonSchema();
       expect(schema['type'], 'integer');
       expect(schema['description'], 'Age');
       expect(schema['minimum'], 0);
@@ -65,11 +66,12 @@ void main() {
     });
 
     test('includes minimum and maximum when provided', () {
-      final schema = Param.number(
-        description: 'Temperature',
-        minimum: -273.15,
-        maximum: 1000,
-      ).toJsonSchema();
+      final schema =
+          Param.number(
+            description: 'Temperature',
+            minimum: -273.15,
+            maximum: 1000,
+          ).toJsonSchema();
       expect(schema['type'], 'number');
       expect(schema['description'], 'Temperature');
       expect(schema['minimum'], -273.15);
@@ -84,9 +86,10 @@ void main() {
     });
 
     test('includes description when provided', () {
-      final schema = Param.boolean(
-        description: 'Whether to include details',
-      ).toJsonSchema();
+      final schema =
+          Param.boolean(
+            description: 'Whether to include details',
+          ).toJsonSchema();
       expect(schema['type'], 'boolean');
       expect(schema['description'], 'Whether to include details');
     });
@@ -94,20 +97,19 @@ void main() {
 
   group('Param.array', () {
     test('produces array schema with items', () {
-      final schema = Param.array(
-        items: Param.string(),
-      ).toJsonSchema();
+      final schema = Param.array(items: Param.string()).toJsonSchema();
       expect(schema['type'], 'array');
       expect(schema['items'], {'type': 'string'});
     });
 
     test('includes minItems and maxItems when provided', () {
-      final schema = Param.array(
-        items: Param.integer(),
-        description: 'List of scores',
-        minItems: 1,
-        maxItems: 10,
-      ).toJsonSchema();
+      final schema =
+          Param.array(
+            items: Param.integer(),
+            description: 'List of scores',
+            minItems: 1,
+            maxItems: 10,
+          ).toJsonSchema();
       expect(schema['type'], 'array');
       expect(schema['items'], {'type': 'integer'});
       expect(schema['description'], 'List of scores');
@@ -124,10 +126,11 @@ void main() {
 
   group('Param.object', () {
     test('produces object schema with properties', () {
-      final schema = Param.object({
-        'name': Param.string(description: 'User name'),
-        'age': Param.integer(),
-      }).toJsonSchema();
+      final schema =
+          Param.object({
+            'name': Param.string(description: 'User name'),
+            'age': Param.integer(),
+          }).toJsonSchema();
 
       expect(schema['type'], 'object');
       final props = schema['properties'] as Map<String, dynamic>;
@@ -136,46 +139,52 @@ void main() {
     });
 
     test('includes required list when provided', () {
-      final schema = Param.object({
-        'name': Param.string(),
-        'age': Param.integer(),
-      }, required: ['name']).toJsonSchema();
+      final schema =
+          Param.object(
+            {'name': Param.string(), 'age': Param.integer()},
+            required: ['name'],
+          ).toJsonSchema();
 
       expect(schema['required'], ['name']);
     });
 
     test('omits required when null', () {
-      final schema = Param.object({
-        'name': Param.string(),
-      }).toJsonSchema();
+      final schema = Param.object({'name': Param.string()}).toJsonSchema();
       expect(schema.containsKey('required'), false);
     });
 
     test('omits required when empty list', () {
-      final schema = Param.object({
-        'name': Param.string(),
-      }, required: []).toJsonSchema();
+      final schema =
+          Param.object({'name': Param.string()}, required: []).toJsonSchema();
       expect(schema.containsKey('required'), false);
     });
 
     test('includes description when provided', () {
-      final schema = Param.object({
-        'x': Param.number(),
-      }, description: 'Coordinate object').toJsonSchema();
+      final schema =
+          Param.object({
+            'x': Param.number(),
+          }, description: 'Coordinate object').toJsonSchema();
       expect(schema['description'], 'Coordinate object');
     });
   });
 
   group('Nested schemas', () {
     test('nested object inside object produces correct deep schema', () {
-      final schema = Param.object({
-        'address': Param.object({
-          'street': Param.string(description: 'Street address'),
-          'city': Param.string(description: 'City name'),
-          'zip': Param.string(),
-        }, required: ['street', 'city']),
-        'name': Param.string(),
-      }, required: ['name', 'address']).toJsonSchema();
+      final schema =
+          Param.object(
+            {
+              'address': Param.object(
+                {
+                  'street': Param.string(description: 'Street address'),
+                  'city': Param.string(description: 'City name'),
+                  'zip': Param.string(),
+                },
+                required: ['street', 'city'],
+              ),
+              'name': Param.string(),
+            },
+            required: ['name', 'address'],
+          ).toJsonSchema();
 
       expect(schema['type'], 'object');
       expect(schema['required'], ['name', 'address']);
@@ -198,12 +207,13 @@ void main() {
     });
 
     test('array of objects produces correct nested schema', () {
-      final schema = Param.array(
-        items: Param.object({
-          'id': Param.integer(),
-          'label': Param.string(),
-        }, required: ['id']),
-      ).toJsonSchema();
+      final schema =
+          Param.array(
+            items: Param.object(
+              {'id': Param.integer(), 'label': Param.string()},
+              required: ['id'],
+            ),
+          ).toJsonSchema();
 
       expect(schema['type'], 'array');
       final items = schema['items'] as Map<String, dynamic>;
@@ -236,10 +246,7 @@ void main() {
 
     test('toJsonSchema returns unmodifiable map', () {
       final schema = Param.string().toJsonSchema();
-      expect(
-        () => schema['extra'] = 'value',
-        throwsA(isA<UnsupportedError>()),
-      );
+      expect(() => schema['extra'] = 'value', throwsA(isA<UnsupportedError>()));
     });
   });
 }

--- a/flutter/test/tool_test.dart
+++ b/flutter/test/tool_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:edge_veda/src/param_builder.dart';
+import 'package:edge_veda/src/tool.dart';
+import 'package:edge_veda/src/tool_types.dart';
+import 'package:edge_veda/src/types.dart';
+
+void main() {
+  late Tool weatherTool;
+
+  setUp(() {
+    weatherTool = Tool(
+      name: 'get_weather',
+      description: 'Get current weather for a location',
+      parameters: Param.object({
+        'location': Param.string(description: 'City name'),
+        'unit': Param.string(
+          description: 'Temperature unit',
+          enumValues: ['celsius', 'fahrenheit'],
+        ),
+      }, required: ['location']),
+      handler: (args) async {
+        final city = args['location'] as String;
+        final unit = args['unit'] as String? ?? 'celsius';
+        return {'temperature': 22, 'unit': unit, 'city': city};
+      },
+    );
+  });
+
+  group('Tool construction', () {
+    test('stores all fields correctly', () {
+      expect(weatherTool.name, 'get_weather');
+      expect(weatherTool.description, 'Get current weather for a location');
+      expect(weatherTool.priority, ToolPriority.required);
+    });
+
+    test('default priority is required', () {
+      final tool = Tool(
+        name: 'test_tool',
+        description: 'A test tool',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async => {'ok': true},
+      );
+      expect(tool.priority, ToolPriority.required);
+    });
+
+    test('accepts optional priority', () {
+      final tool = Tool(
+        name: 'optional_tool',
+        description: 'An optional tool',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async => {'ok': true},
+        priority: ToolPriority.optional,
+      );
+      expect(tool.priority, ToolPriority.optional);
+    });
+  });
+
+  group('toDefinition', () {
+    test('produces valid ToolDefinition with correct fields', () {
+      final def = weatherTool.toDefinition();
+      expect(def.name, 'get_weather');
+      expect(def.description, 'Get current weather for a location');
+      expect(def.parameters['type'], 'object');
+
+      final props = def.parameters['properties'] as Map<String, dynamic>;
+      expect(props.containsKey('location'), true);
+      expect(props.containsKey('unit'), true);
+      expect(def.parameters['required'], ['location']);
+    });
+
+    test('preserves priority', () {
+      final optTool = Tool(
+        name: 'opt_tool',
+        description: 'Optional tool',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async => {},
+        priority: ToolPriority.optional,
+      );
+      final def = optTool.toDefinition();
+      expect(def.priority, ToolPriority.optional);
+    });
+
+    test('throws on invalid name via ToolDefinition validation', () {
+      final badTool = Tool(
+        name: '123invalid',
+        description: 'Bad name',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async => {},
+      );
+      expect(() => badTool.toDefinition(), throwsA(isA<ConfigurationException>()));
+    });
+
+    test('throws on empty description via ToolDefinition validation', () {
+      final badTool = Tool(
+        name: 'good_name',
+        description: '',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async => {},
+      );
+      expect(() => badTool.toDefinition(), throwsA(isA<ConfigurationException>()));
+    });
+  });
+
+  group('execute', () {
+    test('calls handler with correct arguments and returns success', () async {
+      final call = ToolCall(
+        name: 'get_weather',
+        arguments: {'location': 'London', 'unit': 'celsius'},
+      );
+      final result = await weatherTool.execute(call);
+      expect(result.isError, false);
+      expect(result.data!['city'], 'London');
+      expect(result.data!['temperature'], 22);
+      expect(result.data!['unit'], 'celsius');
+      expect(result.toolCallId, call.id);
+    });
+
+    test('catches handler exception and returns failure', () async {
+      final failingTool = Tool(
+        name: 'fail_tool',
+        description: 'A tool that fails',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async {
+          throw Exception('Something went wrong');
+        },
+      );
+      final call = ToolCall(name: 'fail_tool', arguments: {'x': 'test'});
+      final result = await failingTool.execute(call);
+      expect(result.isError, true);
+      expect(result.error, contains('Something went wrong'));
+      expect(result.toolCallId, call.id);
+    });
+
+    test('catches non-Exception errors and returns failure', () async {
+      final errorTool = Tool(
+        name: 'error_tool',
+        description: 'Throws a non-Exception',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async {
+          throw StateError('bad state');
+        },
+      );
+      final call = ToolCall(name: 'error_tool', arguments: {'x': 'test'});
+      final result = await errorTool.execute(call);
+      expect(result.isError, true);
+      expect(result.error, contains('bad state'));
+    });
+
+    test('works with async handler that returns after delay', () async {
+      final slowTool = Tool(
+        name: 'slow_tool',
+        description: 'Slow async tool',
+        parameters: Param.object({'x': Param.string()}),
+        handler: (args) async {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return {'delayed': true};
+        },
+      );
+      final call = ToolCall(name: 'slow_tool', arguments: {'x': 'test'});
+      final result = await slowTool.execute(call);
+      expect(result.isError, false);
+      expect(result.data!['delayed'], true);
+    });
+  });
+
+  group('round-trip', () {
+    test('Param.object parameters round-trip through toDefinition', () {
+      final tool = Tool(
+        name: 'complex_tool',
+        description: 'Tool with complex params',
+        parameters: Param.object({
+          'query': Param.string(description: 'Search query'),
+          'limit': Param.integer(minimum: 1, maximum: 100),
+          'filters': Param.object({
+            'category': Param.string(enumValues: ['a', 'b', 'c']),
+            'active': Param.boolean(),
+          }),
+        }, required: ['query']),
+        handler: (args) async => {'results': []},
+      );
+
+      final def = tool.toDefinition();
+      final params = def.parameters;
+
+      expect(params['type'], 'object');
+      expect(params['required'], ['query']);
+
+      final props = params['properties'] as Map<String, dynamic>;
+      expect(props['query']['type'], 'string');
+      expect(props['query']['description'], 'Search query');
+      expect(props['limit']['type'], 'integer');
+      expect(props['limit']['minimum'], 1);
+      expect(props['limit']['maximum'], 100);
+
+      final filters = props['filters'] as Map<String, dynamic>;
+      expect(filters['type'], 'object');
+      final filterProps = filters['properties'] as Map<String, dynamic>;
+      expect(filterProps['category']['enum'], ['a', 'b', 'c']);
+      expect(filterProps['active']['type'], 'boolean');
+    });
+  });
+}

--- a/flutter/test/tool_test.dart
+++ b/flutter/test/tool_test.dart
@@ -11,13 +11,16 @@ void main() {
     weatherTool = Tool(
       name: 'get_weather',
       description: 'Get current weather for a location',
-      parameters: Param.object({
-        'location': Param.string(description: 'City name'),
-        'unit': Param.string(
-          description: 'Temperature unit',
-          enumValues: ['celsius', 'fahrenheit'],
-        ),
-      }, required: ['location']),
+      parameters: Param.object(
+        {
+          'location': Param.string(description: 'City name'),
+          'unit': Param.string(
+            description: 'Temperature unit',
+            enumValues: ['celsius', 'fahrenheit'],
+          ),
+        },
+        required: ['location'],
+      ),
       handler: (args) async {
         final city = args['location'] as String;
         final unit = args['unit'] as String? ?? 'celsius';
@@ -87,7 +90,10 @@ void main() {
         parameters: Param.object({'x': Param.string()}),
         handler: (args) async => {},
       );
-      expect(() => badTool.toDefinition(), throwsA(isA<ConfigurationException>()));
+      expect(
+        () => badTool.toDefinition(),
+        throwsA(isA<ConfigurationException>()),
+      );
     });
 
     test('throws on empty description via ToolDefinition validation', () {
@@ -97,7 +103,10 @@ void main() {
         parameters: Param.object({'x': Param.string()}),
         handler: (args) async => {},
       );
-      expect(() => badTool.toDefinition(), throwsA(isA<ConfigurationException>()));
+      expect(
+        () => badTool.toDefinition(),
+        throwsA(isA<ConfigurationException>()),
+      );
     });
   });
 
@@ -168,14 +177,17 @@ void main() {
       final tool = Tool(
         name: 'complex_tool',
         description: 'Tool with complex params',
-        parameters: Param.object({
-          'query': Param.string(description: 'Search query'),
-          'limit': Param.integer(minimum: 1, maximum: 100),
-          'filters': Param.object({
-            'category': Param.string(enumValues: ['a', 'b', 'c']),
-            'active': Param.boolean(),
-          }),
-        }, required: ['query']),
+        parameters: Param.object(
+          {
+            'query': Param.string(description: 'Search query'),
+            'limit': Param.integer(minimum: 1, maximum: 100),
+            'filters': Param.object({
+              'category': Param.string(enumValues: ['a', 'b', 'c']),
+              'active': Param.boolean(),
+            }),
+          },
+          required: ['query'],
+        ),
         handler: (args) async => {'results': []},
       );
 


### PR DESCRIPTION
## Summary

- **Param builder**: Type-safe `Param.string()`, `.integer()`, `.number()`, `.boolean()`, `.array()`, `.object()` factories that generate JSON Schema without raw maps
- **Tool class**: Declarative `Tool(name, description, params, handler)` bundles definition + async handler in one object — no separate registry wiring
- **ChatSession.chat()**: Auto-dispatches tool calls in a multi-round loop — generates grammar-constrained tool call JSON, parses it, dispatches to handler, feeds result back, loops until model produces final text response
- **Grammar constraining**: Single-tool calls use exact schema grammar via GbnfBuilder; multi-tool calls use enum-constrained name + generic JSON arguments
- **Backward compatible**: Existing `sendWithTools()` unchanged for power users who want manual dispatch

Closes community feedback: "boilerplate-free tool-calling"

## Test plan

- [ ] `dart pub run test:test test/param_builder_test.dart` — 23 tests pass
- [ ] `dart pub run test:test test/tool_test.dart` — 12 tests pass
- [ ] `dart pub run test:test test/chat_session_tool_test.dart` — 12 integration tests pass
- [ ] `dart analyze flutter/` — no errors
- [ ] Tool definition with Param builder produces valid JSON Schema
- [ ] `chat()` with single tool auto-dispatches and returns final response
- [ ] Grammar constraining produces valid JSON for tool calls