### PR TITLE
feat: full Jinja2 chat template support from GGUF metadata

### DIFF
--- a/core/include/edge_veda.h
+++ b/core/include/edge_veda.h
@@ -504,6 +504,18 @@ typedef struct {
  */
 EV_API ev_error_t ev_get_model_info(ev_context ctx, ev_model_info* info);
 
+/**
+ * @brief Get the chat template string from GGUF model metadata
+ *
+ * Returns the Jinja2 chat template stored in the model's
+ * tokenizer.chat_template metadata field. The returned pointer
+ * is valid until the context is freed.
+ *
+ * @param ctx Context handle
+ * @return Chat template string, or NULL if not found
+ */
+EV_API const char* ev_get_chat_template(ev_context ctx);
+
 /* ============================================================================
  * Utility Functions
  * ========================================================================= */

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -1262,6 +1262,18 @@ ev_error_t ev_get_model_info(ev_context ctx, ev_model_info* info) {
 #endif
 }
 
+const char* ev_get_chat_template(ev_context ctx) {
+    if (!ctx || ctx->magic != EV_CTX_MAGIC) return nullptr;
+#ifdef EDGE_VEDA_LLAMA_ENABLED
+    if (!ctx->model_loaded || !ctx->model) return nullptr;
+    // llama_model_chat_template returns pointer to internal string,
+    // valid until model is freed. Returns nullptr if not found in metadata.
+    return llama_model_chat_template(ctx->model, nullptr);
+#else
+    return nullptr;
+#endif
+}
+
 /* ============================================================================
  * Utility Functions
  * ========================================================================= */

--- a/flutter/lib/src/chat_session.dart
+++ b/flutter/lib/src/chat_session.dart
@@ -40,6 +40,7 @@ import 'dart:convert';
 import 'chat_template.dart';
 import 'chat_types.dart';
 import 'edge_veda_impl.dart';
+import 'jinja_chat_template.dart';
 import 'gbnf_builder.dart';
 import 'json_recovery.dart';
 import 'schema_validator.dart';
@@ -118,6 +119,10 @@ class ChatSession {
   final List<ChatMessage> _messages = [];
   bool _isSummarizing = false;
 
+  /// Compiled Jinja2 template from GGUF metadata, or null if not available
+  /// or if an explicit templateFormat was set.
+  JinjaChatTemplate? _jinjaTemplate;
+
   /// Optional tool registry for function calling support.
   final ToolRegistry? _tools;
 
@@ -136,8 +141,10 @@ class ChatSession {
   /// [systemPrompt] sets a custom system prompt. If null and [preset]
   /// is provided, the preset's prompt text is used instead.
   ///
-  /// [templateFormat] defaults to [ChatTemplateFormat.llama3Instruct]
-  /// for Llama 3.x models. Change this if using a different model family.
+  /// [templateFormat] defaults to [ChatTemplateFormat.auto] which
+  /// auto-detects the Jinja2 template from GGUF model metadata. Change
+  /// this to an explicit value if using a model without GGUF metadata
+  /// or to override auto-detection.
   ///
   /// [maxResponseTokens] reserves space in the context window for the
   /// model's response (defaults to 512 tokens).
@@ -152,7 +159,7 @@ class ChatSession {
     required EdgeVeda edgeVeda,
     String? systemPrompt,
     SystemPromptPreset? preset,
-    this.templateFormat = ChatTemplateFormat.llama3Instruct,
+    this.templateFormat = ChatTemplateFormat.auto,
     int maxResponseTokens = 512,
     ToolRegistry? tools,
     this.onValidationEvent,
@@ -165,6 +172,21 @@ class ChatSession {
       throw const ConfigurationException(
         'EdgeVeda must be initialized before creating a ChatSession. Call init() first.',
       );
+    }
+
+    // Auto-detect Jinja2 template from model metadata
+    if (templateFormat == ChatTemplateFormat.auto) {
+      final templateStr = edgeVeda.chatTemplate;
+      if (templateStr != null && templateStr.isNotEmpty) {
+        try {
+          _jinjaTemplate = JinjaChatTemplate(templateStr);
+        } catch (e) {
+          // Jinja2 compilation failed -- will fall back to hardcoded
+          print(
+            'ChatSession: Jinja2 template compilation failed, using fallback: $e',
+          );
+        }
+      }
     }
   }
 
@@ -631,9 +653,26 @@ class ChatSession {
   }
 
   /// Format the current conversation into a prompt string
+  ///
+  /// Uses the Jinja2 template when available (auto mode with valid template),
+  /// falling back to hardcoded templates on failure or explicit format.
   String _formatConversation() {
+    if (_jinjaTemplate != null) {
+      try {
+        return _jinjaTemplate!.format(
+          messages: _messages,
+          systemPrompt: systemPrompt,
+          addGenerationPrompt: true,
+        );
+      } catch (e) {
+        // Jinja2 evaluation failed -- fall through to hardcoded
+        print('ChatSession: Jinja2 evaluation failed, using fallback: $e');
+      }
+    }
     return ChatTemplate.format(
-      template: templateFormat,
+      template: templateFormat == ChatTemplateFormat.auto
+          ? ChatTemplateFormat.llama3Instruct
+          : templateFormat,
       systemPrompt: systemPrompt,
       messages: _messages,
     );
@@ -641,23 +680,47 @@ class ChatSession {
 
   /// Format conversation with tool definitions injected into the system prompt.
   ///
-  /// If tools are registered, combines the system prompt with tool definitions
-  /// via [ToolTemplate.formatToolSystemPrompt]. Falls back to normal formatting
-  /// if no tools are registered.
+  /// If tools are registered, combines the system prompt with tool definitions.
+  /// When Jinja2 template is available, passes tools as template variables
+  /// for model-native formatting. Falls back to hardcoded tool formatting
+  /// if Jinja2 fails or is not available.
   String _formatConversationWithTools() {
     final tools = _tools;
     if (tools == null || tools.tools.isEmpty) {
       return _formatConversation();
     }
 
+    // Jinja2 path: pass tools as template variables for model-native formatting
+    if (_jinjaTemplate != null) {
+      try {
+        final toolDefs = tools.tools.map((t) => t.toFunctionJson()).toList();
+        return _jinjaTemplate!.format(
+          messages: _messages,
+          systemPrompt: systemPrompt,
+          addGenerationPrompt: true,
+          tools: toolDefs,
+        );
+      } catch (e) {
+        // Fall through to hardcoded tool formatting
+        print(
+          'ChatSession: Jinja2 tool formatting failed, using fallback: $e',
+        );
+      }
+    }
+
+    // Hardcoded path: use ToolTemplate to inject tools into system prompt
     final toolSystemPrompt = ToolTemplate.formatToolSystemPrompt(
-      format: templateFormat,
+      format: templateFormat == ChatTemplateFormat.auto
+          ? ChatTemplateFormat.llama3Instruct
+          : templateFormat,
       tools: tools.tools,
       systemPrompt: systemPrompt,
     );
 
     return ChatTemplate.format(
-      template: templateFormat,
+      template: templateFormat == ChatTemplateFormat.auto
+          ? ChatTemplateFormat.llama3Instruct
+          : templateFormat,
       systemPrompt: toolSystemPrompt,
       messages: _messages,
     );

--- a/flutter/lib/src/chat_session.dart
+++ b/flutter/lib/src/chat_session.dart
@@ -670,9 +670,10 @@ class ChatSession {
       }
     }
     return ChatTemplate.format(
-      template: templateFormat == ChatTemplateFormat.auto
-          ? ChatTemplateFormat.llama3Instruct
-          : templateFormat,
+      template:
+          templateFormat == ChatTemplateFormat.auto
+              ? ChatTemplateFormat.llama3Instruct
+              : templateFormat,
       systemPrompt: systemPrompt,
       messages: _messages,
     );
@@ -702,25 +703,25 @@ class ChatSession {
         );
       } catch (e) {
         // Fall through to hardcoded tool formatting
-        print(
-          'ChatSession: Jinja2 tool formatting failed, using fallback: $e',
-        );
+        print('ChatSession: Jinja2 tool formatting failed, using fallback: $e');
       }
     }
 
     // Hardcoded path: use ToolTemplate to inject tools into system prompt
     final toolSystemPrompt = ToolTemplate.formatToolSystemPrompt(
-      format: templateFormat == ChatTemplateFormat.auto
-          ? ChatTemplateFormat.llama3Instruct
-          : templateFormat,
+      format:
+          templateFormat == ChatTemplateFormat.auto
+              ? ChatTemplateFormat.llama3Instruct
+              : templateFormat,
       tools: tools.tools,
       systemPrompt: systemPrompt,
     );
 
     return ChatTemplate.format(
-      template: templateFormat == ChatTemplateFormat.auto
-          ? ChatTemplateFormat.llama3Instruct
-          : templateFormat,
+      template:
+          templateFormat == ChatTemplateFormat.auto
+              ? ChatTemplateFormat.llama3Instruct
+              : templateFormat,
       systemPrompt: toolSystemPrompt,
       messages: _messages,
     );

--- a/flutter/lib/src/chat_template.dart
+++ b/flutter/lib/src/chat_template.dart
@@ -19,6 +19,13 @@ import 'chat_types.dart';
 /// responses are delimited in the prompt string. Using the wrong template
 /// for a model will produce garbage output.
 enum ChatTemplateFormat {
+  /// Automatic detection from GGUF model metadata (recommended).
+  ///
+  /// When used with [ChatSession], the Jinja2 template from the model's
+  /// GGUF metadata is evaluated directly. Falls back to [llama3Instruct]
+  /// if no template is found or evaluation fails.
+  auto,
+
   /// Llama 3 Instruct format (default for Llama-3.x-Instruct models)
   ///
   /// Uses `<|begin_of_text|>`, `<|start_header_id|>`, `<|end_header_id|>`,
@@ -80,6 +87,10 @@ class ChatTemplate {
     required List<ChatMessage> messages,
   }) {
     switch (template) {
+      case ChatTemplateFormat.auto:
+        // Auto should be resolved before reaching here.
+        // If it gets here, fall back to Llama3 format.
+        return _formatLlama3Instruct(systemPrompt, messages);
       case ChatTemplateFormat.llama3Instruct:
         return _formatLlama3Instruct(systemPrompt, messages);
       case ChatTemplateFormat.chatML:

--- a/flutter/lib/src/edge_veda_impl.dart
+++ b/flutter/lib/src/edge_veda_impl.dart
@@ -104,6 +104,9 @@ class EdgeVeda {
   /// Optional Scheduler for budget-aware image generation
   Scheduler? _scheduler;
 
+  /// Cached Jinja2 chat template string from GGUF model metadata
+  String? _chatTemplate;
+
   // Note: NO Pointer storage here - pointers can't transfer between isolates
 
   /// Whether the SDK is initialized
@@ -120,6 +123,12 @@ class EdgeVeda {
 
   /// Current configuration
   EdgeVedaConfig? get config => _config;
+
+  /// The Jinja2 chat template string from GGUF model metadata, or null.
+  ///
+  /// Available after [init]. Returns the raw Jinja2 template that the
+  /// model was trained with. Used by [ChatSession] for auto-detection.
+  String? get chatTemplate => _chatTemplate;
 
   /// Connect a [Scheduler] for budget-aware image generation.
   ///
@@ -161,8 +170,10 @@ class EdgeVeda {
 
     // Test initialization in background isolate to verify model loads
     // Pass only primitive data - no Pointers!
+    // Returns the chat template string from GGUF metadata (or null).
+    String? chatTemplateResult;
     try {
-      await Isolate.run<void>(() {
+      chatTemplateResult = await Isolate.run<String?>(() {
         final bindings = EdgeVedaNativeBindings.instance; // Re-load in isolate
 
         // Allocate config struct
@@ -196,8 +207,17 @@ class EdgeVeda {
             throw exception ??
                 const InitializationException('Unknown init error');
           }
-          // Immediately free - we just tested it works
+
+          // Extract chat template from GGUF metadata before freeing
+          String? template;
+          try {
+            template = bindings.getChatTemplate(ctx);
+          } catch (_) {
+            // Non-fatal: template extraction is best-effort
+          }
+
           bindings.evFree(ctx);
+          return template;
         } finally {
           calloc.free(modelPathPtr);
           calloc.free(configPtr);
@@ -215,6 +235,7 @@ class EdgeVeda {
     }
 
     _config = config;
+    _chatTemplate = chatTemplateResult;
     _isInitialized = true;
   }
 

--- a/flutter/lib/src/ffi/bindings.dart
+++ b/flutter/lib/src/ffi/bindings.dart
@@ -831,12 +831,10 @@ typedef EvFreeEmbeddingsDart = void Function(Pointer<EvEmbedResult> result);
 // =============================================================================
 
 /// const char* ev_get_chat_template(ev_context ctx)
-typedef EvGetChatTemplateNative = Pointer<Utf8> Function(
-  Pointer<EvContextImpl> ctx,
-);
-typedef EvGetChatTemplateDart = Pointer<Utf8> Function(
-  Pointer<EvContextImpl> ctx,
-);
+typedef EvGetChatTemplateNative =
+    Pointer<Utf8> Function(Pointer<EvContextImpl> ctx);
+typedef EvGetChatTemplateDart =
+    Pointer<Utf8> Function(Pointer<EvContextImpl> ctx);
 
 // =============================================================================
 // Image Generation Function Types (matching edge_veda.h Image Generation API)

--- a/flutter/lib/src/ffi/bindings.dart
+++ b/flutter/lib/src/ffi/bindings.dart
@@ -827,6 +827,18 @@ typedef EvFreeEmbeddingsNative = Void Function(Pointer<EvEmbedResult> result);
 typedef EvFreeEmbeddingsDart = void Function(Pointer<EvEmbedResult> result);
 
 // =============================================================================
+// Chat Template Function Types
+// =============================================================================
+
+/// const char* ev_get_chat_template(ev_context ctx)
+typedef EvGetChatTemplateNative = Pointer<Utf8> Function(
+  Pointer<EvContextImpl> ctx,
+);
+typedef EvGetChatTemplateDart = Pointer<Utf8> Function(
+  Pointer<EvContextImpl> ctx,
+);
+
+// =============================================================================
 // Image Generation Function Types (matching edge_veda.h Image Generation API)
 // =============================================================================
 
@@ -1122,6 +1134,23 @@ class EdgeVedaNativeBindings {
   late final EvFreeEmbeddingsDart evFreeEmbeddings;
 
   // ---------------------------------------------------------------------------
+  // Chat Template Functions
+  // ---------------------------------------------------------------------------
+
+  /// Get chat template string from GGUF model metadata
+  late final EvGetChatTemplateDart evGetChatTemplate;
+
+  /// Get chat template as Dart String, or null if not available.
+  ///
+  /// The returned string is the raw Jinja2 template from GGUF metadata.
+  /// Valid only while the context is alive.
+  String? getChatTemplate(Pointer<EvContextImpl> ctx) {
+    final ptr = evGetChatTemplate(ctx);
+    if (ptr == nullptr) return null;
+    return ptr.toDartString();
+  }
+
+  // ---------------------------------------------------------------------------
   // Image Generation Functions
   // ---------------------------------------------------------------------------
 
@@ -1314,6 +1343,12 @@ class EdgeVedaNativeBindings {
     evFreeEmbeddings = _dylib
         .lookupFunction<EvFreeEmbeddingsNative, EvFreeEmbeddingsDart>(
           'ev_free_embeddings',
+        );
+
+    // Chat template
+    evGetChatTemplate = _dylib
+        .lookupFunction<EvGetChatTemplateNative, EvGetChatTemplateDart>(
+          'ev_get_chat_template',
         );
 
     // Streaming confidence

--- a/flutter/lib/src/jinja_chat_template.dart
+++ b/flutter/lib/src/jinja_chat_template.dart
@@ -36,7 +36,7 @@ class JinjaChatTemplate {
   /// The template is compiled immediately. Throws if the template
   /// has syntax errors.
   JinjaChatTemplate(this.templateString)
-      : _compiled = _createEnvironment().fromString(templateString);
+    : _compiled = _createEnvironment().fromString(templateString);
 
   /// Format a conversation using the Jinja2 template.
   ///

--- a/flutter/lib/src/jinja_chat_template.dart
+++ b/flutter/lib/src/jinja_chat_template.dart
@@ -1,0 +1,125 @@
+/// Dynamic Jinja2 chat template evaluator
+///
+/// Evaluates Jinja2 template strings extracted from GGUF model metadata.
+/// Replaces hardcoded per-model template formatting with dynamic evaluation.
+///
+/// The template is compiled once at construction time and reused for all
+/// format() calls. Uses HuggingFace-compatible Environment settings:
+/// trimBlocks=true, leftStripBlocks=true.
+library;
+
+import 'package:jinja/jinja.dart';
+
+import 'chat_types.dart';
+
+/// Evaluates Jinja2 chat templates from GGUF model metadata.
+///
+/// Construct with the raw Jinja2 template string from GGUF metadata.
+/// Call [format] to render a conversation into a model-specific prompt.
+///
+/// Example:
+/// ```dart
+/// final tmpl = JinjaChatTemplate(templateString);
+/// final prompt = tmpl.format(
+///   messages: [ChatMessage(role: ChatRole.user, content: 'Hi', timestamp: DateTime.now())],
+///   systemPrompt: 'You are helpful.',
+/// );
+/// ```
+class JinjaChatTemplate {
+  /// The raw Jinja2 template string from GGUF metadata.
+  final String templateString;
+
+  final Template _compiled;
+
+  /// Create a JinjaChatTemplate from a raw Jinja2 template string.
+  ///
+  /// The template is compiled immediately. Throws if the template
+  /// has syntax errors.
+  JinjaChatTemplate(this.templateString)
+      : _compiled = _createEnvironment().fromString(templateString);
+
+  /// Format a conversation using the Jinja2 template.
+  ///
+  /// [messages] is the conversation history.
+  /// [systemPrompt] is prepended as a system message if provided.
+  /// [addGenerationPrompt] appends the assistant turn marker (default true).
+  /// [tools] is an optional list of tool definitions in OpenAI-compatible
+  /// format: `[{"type": "function", "function": {"name": ..., ...}}]`.
+  /// [bosToken] and [eosToken] default to empty strings.
+  String format({
+    required List<ChatMessage> messages,
+    String? systemPrompt,
+    bool addGenerationPrompt = true,
+    List<Map<String, dynamic>>? tools,
+    String bosToken = '',
+    String eosToken = '',
+  }) {
+    final jinjaMessages = _toJinjaMessages(messages, systemPrompt);
+    return _compiled.render({
+      'messages': jinjaMessages,
+      'add_generation_prompt': addGenerationPrompt,
+      'bos_token': bosToken,
+      'eos_token': eosToken,
+      if (tools != null) 'tools': tools,
+    });
+  }
+
+  /// Convert EdgeVeda ChatMessage list to Jinja2-compatible message dicts.
+  ///
+  /// Maps ChatRole values to standard HuggingFace role strings.
+  /// Prepends systemPrompt as a system message if provided.
+  static List<Map<String, dynamic>> _toJinjaMessages(
+    List<ChatMessage> messages,
+    String? systemPrompt,
+  ) {
+    final result = <Map<String, dynamic>>[];
+
+    if (systemPrompt != null && systemPrompt.isNotEmpty) {
+      result.add({'role': 'system', 'content': systemPrompt});
+    }
+
+    for (final msg in messages) {
+      final role = switch (msg.role) {
+        ChatRole.user => 'user',
+        ChatRole.assistant => 'assistant',
+        ChatRole.system => 'system',
+        ChatRole.toolCall => 'assistant',
+        ChatRole.toolResult => 'tool',
+        ChatRole.summary => 'system',
+      };
+
+      final entry = <String, dynamic>{'role': role, 'content': msg.content};
+      result.add(entry);
+    }
+
+    return result;
+  }
+
+  /// Create a Jinja2 Environment matching HuggingFace conventions.
+  ///
+  /// Settings:
+  /// - trimBlocks: true (remove first newline after block tag)
+  /// - leftStripBlocks: true (strip leading whitespace from block tags)
+  ///
+  /// Custom globals registered:
+  /// - raise_exception(msg): throws an exception (used by some templates
+  ///   to reject unsupported features)
+  /// - strftime_now(fmt): returns empty string (placeholder; on-device
+  ///   models rarely need real-time formatting)
+  static Environment _createEnvironment() {
+    return Environment(
+      trimBlocks: true,
+      leftStripBlocks: true,
+      globals: {
+        'raise_exception': (String message) {
+          throw Exception('Template error: $message');
+        },
+        'strftime_now': (String format) {
+          // Simplified: return empty string. Real implementation would
+          // format DateTime.now() but this is rarely used in practice.
+          return '';
+        },
+      },
+    );
+  }
+}

--- a/flutter/lib/src/tool_template.dart
+++ b/flutter/lib/src/tool_template.dart
@@ -52,6 +52,10 @@ class ToolTemplate {
     String? systemPrompt,
   }) {
     switch (format) {
+      case ChatTemplateFormat.auto:
+        // When in auto mode, use Qwen3-style as default since it's most common
+        // (but this path is rarely hit -- Jinja2 handles tools natively)
+        return _formatQwen3ToolPrompt(tools, systemPrompt);
       case ChatTemplateFormat.qwen3:
         return _formatQwen3ToolPrompt(tools, systemPrompt);
       case ChatTemplateFormat.gemma3:
@@ -80,6 +84,9 @@ class ToolTemplate {
     required String output,
   }) {
     switch (format) {
+      case ChatTemplateFormat.auto:
+        // Try Qwen3 (most common) first, then Gemma3 as fallback
+        return _parseQwen3ToolCalls(output) ?? _parseGemma3ToolCalls(output);
       case ChatTemplateFormat.qwen3:
         return _parseQwen3ToolCalls(output);
       case ChatTemplateFormat.gemma3:
@@ -104,6 +111,11 @@ class ToolTemplate {
     required String output,
   }) {
     switch (format) {
+      case ChatTemplateFormat.auto:
+        // Check both formats
+        if (output.contains('<tool_call>')) return true;
+        final autoTrimmed = output.trimLeft();
+        return autoTrimmed.startsWith('{') && autoTrimmed.contains('"name"');
       case ChatTemplateFormat.qwen3:
         return output.contains('<tool_call>');
       case ChatTemplateFormat.gemma3:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   ffi: "^2.0.0"
   http: ^1.2.0
   image: ^4.0.0
+  jinja: ^0.6.4
   json_schema: ^5.0.0
   local_hnsw: ^1.0.0
   path: ^1.9.0

--- a/flutter/test/jinja_chat_template_test.dart
+++ b/flutter/test/jinja_chat_template_test.dart
@@ -365,10 +365,7 @@ void main() {
 
   group('Error handling', () {
     test('invalid template string throws at construction time', () {
-      expect(
-        () => JinjaChatTemplate('{% if %}'),
-        throwsA(isA<Exception>()),
-      );
+      expect(() => JinjaChatTemplate('{% if %}'), throwsA(isA<Exception>()));
     });
 
     test('template calling raise_exception produces a Dart exception', () {
@@ -376,10 +373,7 @@ void main() {
         "{{ raise_exception('feature not supported') }}",
       );
 
-      expect(
-        () => tmpl.format(messages: []),
-        throwsA(isA<Exception>()),
-      );
+      expect(() => tmpl.format(messages: []), throwsA(isA<Exception>()));
     });
   });
 }

--- a/flutter/test/jinja_chat_template_test.dart
+++ b/flutter/test/jinja_chat_template_test.dart
@@ -4,44 +4,44 @@ import 'package:test/test.dart';
 
 /// Real Llama 3 Instruct Jinja2 template from GGUF metadata.
 const _llama3Template =
-    "{% set loop_messages = messages %}"
-    "{% for message in loop_messages %}"
+    '{% set loop_messages = messages %}'
+    '{% for message in loop_messages %}'
     "{% set content = '<|start_header_id|>' + message['role'] + "
     "'<|end_header_id|>\n\n' + message['content'] | trim + '<|eot_id|>' %}"
-    "{% if loop.first %}{% set content = bos_token + content %}{% endif %}"
-    "{{ content }}"
-    "{% endfor %}"
-    "{% if add_generation_prompt %}"
+    '{% if loop.first %}{% set content = bos_token + content %}{% endif %}'
+    '{{ content }}'
+    '{% endfor %}'
+    '{% if add_generation_prompt %}'
     "{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}"
-    "{% endif %}";
+    '{% endif %}';
 
 /// Standard ChatML template used by many open models.
 const _chatMLTemplate =
-    "{% for message in messages %}"
+    '{% for message in messages %}'
     "{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}"
-    "{% endfor %}"
-    "{% if add_generation_prompt %}"
+    '{% endfor %}'
+    '{% if add_generation_prompt %}'
     "{{'<|im_start|>assistant\n'}}"
-    "{% endif %}";
+    '{% endif %}';
 
 /// Simplified tool-aware template inspired by Qwen3-style patterns.
 /// Checks for a `tools` variable and renders tool definitions before the
 /// conversation when present.
 const _toolAwareTemplate =
-    "{% if tools is defined and tools %}"
-    "<|im_start|>system\n"
-    "You have access to the following tools:\n"
-    "{% for tool in tools %}"
+    '{% if tools is defined and tools %}'
+    '<|im_start|>system\n'
+    'You have access to the following tools:\n'
+    '{% for tool in tools %}'
     "- {{ tool['function']['name'] }}: {{ tool['function']['description'] }}\n"
-    "{% endfor %}"
-    "<|im_end|>\n"
-    "{% endif %}"
-    "{% for message in messages %}"
+    '{% endfor %}'
+    '<|im_end|>\n'
+    '{% endif %}'
+    '{% for message in messages %}'
     "{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}"
-    "{% endfor %}"
-    "{% if add_generation_prompt %}"
+    '{% endfor %}'
+    '{% if add_generation_prompt %}'
     "{{'<|im_start|>assistant\n'}}"
-    "{% endif %}";
+    '{% endif %}';
 
 void main() {
   group('Llama 3 Instruct template', () {
@@ -293,11 +293,11 @@ void main() {
     test('bos_token and eos_token are injected into template output', () {
       // Template that explicitly uses bos_token and eos_token
       const tokenTemplate =
-          "{{ bos_token }}"
-          "{% for message in messages %}"
+          '{{ bos_token }}'
+          '{% for message in messages %}'
           "{{ message['content'] }}"
-          "{% endfor %}"
-          "{{ eos_token }}";
+          '{% endfor %}'
+          '{{ eos_token }}';
 
       final tmpl = JinjaChatTemplate(tokenTemplate);
       final result = tmpl.format(

--- a/flutter/test/jinja_chat_template_test.dart
+++ b/flutter/test/jinja_chat_template_test.dart
@@ -1,0 +1,385 @@
+import 'package:edge_veda/src/chat_types.dart';
+import 'package:edge_veda/src/jinja_chat_template.dart';
+import 'package:test/test.dart';
+
+/// Real Llama 3 Instruct Jinja2 template from GGUF metadata.
+const _llama3Template =
+    "{% set loop_messages = messages %}"
+    "{% for message in loop_messages %}"
+    "{% set content = '<|start_header_id|>' + message['role'] + "
+    "'<|end_header_id|>\n\n' + message['content'] | trim + '<|eot_id|>' %}"
+    "{% if loop.first %}{% set content = bos_token + content %}{% endif %}"
+    "{{ content }}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}"
+    "{% endif %}";
+
+/// Standard ChatML template used by many open models.
+const _chatMLTemplate =
+    "{% for message in messages %}"
+    "{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{'<|im_start|>assistant\n'}}"
+    "{% endif %}";
+
+/// Simplified tool-aware template inspired by Qwen3-style patterns.
+/// Checks for a `tools` variable and renders tool definitions before the
+/// conversation when present.
+const _toolAwareTemplate =
+    "{% if tools is defined and tools %}"
+    "<|im_start|>system\n"
+    "You have access to the following tools:\n"
+    "{% for tool in tools %}"
+    "- {{ tool['function']['name'] }}: {{ tool['function']['description'] }}\n"
+    "{% endfor %}"
+    "<|im_end|>\n"
+    "{% endif %}"
+    "{% for message in messages %}"
+    "{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{'<|im_start|>assistant\n'}}"
+    "{% endif %}";
+
+void main() {
+  group('Llama 3 Instruct template', () {
+    late JinjaChatTemplate tmpl;
+
+    setUp(() {
+      tmpl = JinjaChatTemplate(_llama3Template);
+    });
+
+    test('system + user message produces correct Llama 3 format', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hello!',
+            timestamp: DateTime.now(),
+          ),
+        ],
+        systemPrompt: 'You are helpful.',
+      );
+
+      expect(
+        result,
+        equals(
+          '<|start_header_id|>system<|end_header_id|>\n\n'
+          'You are helpful.<|eot_id|>'
+          '<|start_header_id|>user<|end_header_id|>\n\n'
+          'Hello!<|eot_id|>'
+          '<|start_header_id|>assistant<|end_header_id|>\n\n',
+        ),
+      );
+    });
+
+    test('multi-turn conversation produces correct format', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hi',
+            timestamp: DateTime.now(),
+          ),
+          ChatMessage(
+            role: ChatRole.assistant,
+            content: 'Hello! How can I help?',
+            timestamp: DateTime.now(),
+          ),
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Tell me a joke.',
+            timestamp: DateTime.now(),
+          ),
+        ],
+        systemPrompt: 'You are helpful.',
+      );
+
+      expect(result, contains('<|start_header_id|>system<|end_header_id|>'));
+      expect(
+        result,
+        contains(
+          'Hi<|eot_id|>'
+          '<|start_header_id|>assistant<|end_header_id|>\n\n'
+          'Hello! How can I help?<|eot_id|>',
+        ),
+      );
+      expect(
+        result,
+        endsWith('<|start_header_id|>assistant<|end_header_id|>\n\n'),
+      );
+    });
+
+    test('no system prompt still works', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hello!',
+            timestamp: DateTime.now(),
+          ),
+        ],
+      );
+
+      expect(
+        result,
+        equals(
+          '<|start_header_id|>user<|end_header_id|>\n\n'
+          'Hello!<|eot_id|>'
+          '<|start_header_id|>assistant<|end_header_id|>\n\n',
+        ),
+      );
+    });
+
+    test('bos_token is injected when provided', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hello!',
+            timestamp: DateTime.now(),
+          ),
+        ],
+        bosToken: '<s>',
+      );
+
+      expect(result, startsWith('<s><|start_header_id|>'));
+    });
+  });
+
+  group('ChatML template', () {
+    late JinjaChatTemplate tmpl;
+
+    setUp(() {
+      tmpl = JinjaChatTemplate(_chatMLTemplate);
+    });
+
+    test('produces correct im_start/im_end format', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hi',
+            timestamp: DateTime.now(),
+          ),
+        ],
+        systemPrompt: 'You are helpful.',
+      );
+
+      expect(
+        result,
+        equals(
+          '<|im_start|>system\n'
+          'You are helpful.<|im_end|>\n'
+          '<|im_start|>user\n'
+          'Hi<|im_end|>\n'
+          '<|im_start|>assistant\n',
+        ),
+      );
+    });
+
+    test('add_generation_prompt=false omits final assistant marker', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hi',
+            timestamp: DateTime.now(),
+          ),
+        ],
+        systemPrompt: 'You are helpful.',
+        addGenerationPrompt: false,
+      );
+
+      expect(result, isNot(contains('<|im_start|>assistant')));
+      expect(result, endsWith('<|im_end|>\n'));
+    });
+  });
+
+  group('Tool injection', () {
+    late JinjaChatTemplate tmpl;
+
+    setUp(() {
+      tmpl = JinjaChatTemplate(_toolAwareTemplate);
+    });
+
+    test('tools list appears in rendered output', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'What is the weather?',
+            timestamp: DateTime.now(),
+          ),
+        ],
+        tools: [
+          {
+            'type': 'function',
+            'function': {
+              'name': 'get_weather',
+              'description': 'Get current weather for a location',
+            },
+          },
+        ],
+      );
+
+      expect(result, contains('get_weather'));
+      expect(result, contains('Get current weather for a location'));
+      expect(result, contains('<|im_start|>user'));
+    });
+
+    test('no tools renders without error', () {
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hello',
+            timestamp: DateTime.now(),
+          ),
+        ],
+      );
+
+      expect(result, isNot(contains('tools')));
+      expect(result, contains('<|im_start|>user'));
+    });
+  });
+
+  group('Edge cases', () {
+    test('empty messages list', () {
+      final tmpl = JinjaChatTemplate(_chatMLTemplate);
+      final result = tmpl.format(messages: []);
+
+      // With no messages and add_generation_prompt=true, just the assistant
+      // prompt marker should appear.
+      expect(result, equals('<|im_start|>assistant\n'));
+    });
+
+    test('message with empty content', () {
+      final tmpl = JinjaChatTemplate(_chatMLTemplate);
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: '',
+            timestamp: DateTime.now(),
+          ),
+        ],
+      );
+
+      expect(result, contains('<|im_start|>user\n<|im_end|>'));
+    });
+
+    test('template with set variable assignments', () {
+      const templateWithSet =
+          "{% set greeting = 'Hello' %}"
+          "{{ greeting }} {{ messages[0]['content'] }}";
+
+      final tmpl = JinjaChatTemplate(templateWithSet);
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'World',
+            timestamp: DateTime.now(),
+          ),
+        ],
+      );
+
+      expect(result, equals('Hello World'));
+    });
+
+    test('bos_token and eos_token are injected into template output', () {
+      // Template that explicitly uses bos_token and eos_token
+      const tokenTemplate =
+          "{{ bos_token }}"
+          "{% for message in messages %}"
+          "{{ message['content'] }}"
+          "{% endfor %}"
+          "{{ eos_token }}";
+
+      final tmpl = JinjaChatTemplate(tokenTemplate);
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.user,
+            content: 'Hi',
+            timestamp: DateTime.now(),
+          ),
+        ],
+        bosToken: '<s>',
+        eosToken: '</s>',
+      );
+
+      expect(result, startsWith('<s>'));
+      expect(result, endsWith('</s>'));
+      expect(result, equals('<s>Hi</s>'));
+    });
+
+    test('ChatRole.toolCall maps to assistant role', () {
+      final tmpl = JinjaChatTemplate(_chatMLTemplate);
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.toolCall,
+            content: '{"name": "get_weather"}',
+            timestamp: DateTime.now(),
+          ),
+        ],
+      );
+
+      expect(result, contains('<|im_start|>assistant'));
+    });
+
+    test('ChatRole.toolResult maps to tool role', () {
+      final tmpl = JinjaChatTemplate(_chatMLTemplate);
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.toolResult,
+            content: '{"temperature": 72}',
+            timestamp: DateTime.now(),
+          ),
+        ],
+      );
+
+      expect(result, contains('<|im_start|>tool'));
+    });
+
+    test('ChatRole.summary maps to system role', () {
+      final tmpl = JinjaChatTemplate(_chatMLTemplate);
+      final result = tmpl.format(
+        messages: [
+          ChatMessage(
+            role: ChatRole.summary,
+            content: 'Previous conversation about weather.',
+            timestamp: DateTime.now(),
+          ),
+        ],
+      );
+
+      expect(result, contains('<|im_start|>system'));
+    });
+  });
+
+  group('Error handling', () {
+    test('invalid template string throws at construction time', () {
+      expect(
+        () => JinjaChatTemplate('{% if %}'),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('template calling raise_exception produces a Dart exception', () {
+      final tmpl = JinjaChatTemplate(
+        "{{ raise_exception('feature not supported') }}",
+      );
+
+      expect(
+        () => tmpl.format(messages: []),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `ev_get_chat_template()` C API function that extracts Jinja2 template strings from GGUF model metadata via llama.cpp
- Creates `JinjaChatTemplate` pure-Dart class using the `jinja` package to dynamically evaluate any HuggingFace-compatible Jinja2 chat template
- Integrates into `ChatSession` with `ChatTemplateFormat.auto` (new default) — automatically detects and uses the model's native template, with hardcoded fallback
- Tool definitions are passed as Jinja2 template variables for model-native tool formatting
- 17 unit tests covering Llama3 Instruct, ChatML, tool injection, edge cases, and error handling

**Requirements covered:** JNJ2-01 through JNJ2-05

## Changes

| File | Change |
|------|--------|
| `core/include/edge_veda.h` | `ev_get_chat_template()` declaration |
| `core/src/engine.cpp` | Implementation wrapping `llama_model_chat_template` |
| `flutter/lib/src/ffi/bindings.dart` | FFI typedef + `getChatTemplate()` convenience method |
| `flutter/pubspec.yaml` | Added `jinja: ^0.6.4` dependency |
| `flutter/lib/src/jinja_chat_template.dart` | `JinjaChatTemplate` class with HF-compatible Environment |
| `flutter/lib/src/chat_template.dart` | `ChatTemplateFormat.auto` enum value |
| `flutter/lib/src/edge_veda_impl.dart` | `chatTemplate` getter, cached during init |
| `flutter/lib/src/chat_session.dart` | Jinja2 auto-detection with fallback chain |
| `flutter/lib/src/tool_template.dart` | `auto` case handling in all switch statements |
| `flutter/test/jinja_chat_template_test.dart` | 17 comprehensive tests |

## Test plan

- [x] `dart test test/jinja_chat_template_test.dart` — all 17 tests pass
- [x] `dart analyze` — no errors on all modified Dart files
- [ ] Device test: load a GGUF model with chat_template metadata, verify auto-detection works
- [ ] Verify backward compat: explicit `ChatTemplateFormat.llama3Instruct` produces identical output as before